### PR TITLE
patch(comp > spacing): improves docs

### DIFF
--- a/packages/wethegit-components/src/utilities/spacing/spacing.module.scss
+++ b/packages/wethegit-components/src/utilities/spacing/spacing.module.scss
@@ -1,6 +1,6 @@
 @use "@local/styles/settings/settings-breakpoints.scss" as *;
+@use "./styles/spacing-utilities" as *;
 
-$space-by: 8px;
 $total-space-classes: 10;
 
 /**
@@ -12,21 +12,7 @@ $total-space-classes: 10;
   *
   * Examples:
   * margin-0, padding-x-2, margin-x-auto, margin-bottom-medium-3, padding-x-large-4
-*/
-
-// Creates a value which is a multiple of the $base-space property.
-@function space-by($multiplier: false) {
-  @if not $multiplier {
-    @return $space-by;
-  } @else if $multiplier == 1 {
-    @return $space-by;
-  } @else {
-    @return $space-by * $multiplier;
-  }
-}
-
-/**
-  * Generates a set of utility classes for margin and padding.
+  *
   * @param {Number} $total - The total number of classes to generate (0 through $total). Sizes are based on the $base-space property.
   * @param {String} $suffix - An optional suffix to append to the class name.
   */

--- a/packages/wethegit-components/src/utilities/spacing/spacing.stories.mdx
+++ b/packages/wethegit-components/src/utilities/spacing/spacing.stories.mdx
@@ -6,7 +6,7 @@ import { Meta } from "@storybook/blocks"
 
 The spacing utility exposes a set of classes that can be used to add margin and padding to elements.
 
-By default it's based on a `8px` grid but can be configured to use any value by simply changing the `$space-by` variable inside `spacing.module.scss`.
+By default it's based on a `8px` grid but can be configured to use any value by simply changing the `$spacing-unit` variable inside `styles/_spacing-utilities.scss`.
 
 So for example if you wanted `16px` of margin you would simply use `spacing.margin[2]`.
 
@@ -63,4 +63,41 @@ import { classnames, spacing } from "@local/utilities"
 function Comp() {
   return <div className={classnames([spacing.margin[2], spacing.md.margin[3]])} />
 }
+```
+
+### Styles and Sass
+
+You can also use the Sass function `space-by()` to get the value of a spacing unit.
+Read more about the function [here](/docs/utilities-spacing-styles-spacing-utilities--docs).
+
+```css
+@use "@local/utilities/spacing/styles/spacing-utilities" as *;
+
+.my-class {
+  margin: space-by(2);
+}
+```
+
+## No JS
+
+If you do not want to use the JS version of the spacing utility you can easily do so by:
+
+1. Remove any imports of `spacing` from your code
+2. Rename `spacing.module.scss` to `spacing.scss`
+3. Import `spacing.scss` in your global styles
+
+And then proceed to use the classes as you would normally do.
+
+```html
+<div class="margin-top-2 padding-x-3" />
+```
+
+The biggest difference from the CSS classes to the JS classes is that in the JS classes the **breakpoint comes first**:
+
+```jsx
+<div className={spacing.large.margin.right[2]} />
+```
+
+```html
+<div class="margin-right-large-2" />
 ```

--- a/packages/wethegit-components/src/utilities/spacing/styles/_spacing-utilities.scss
+++ b/packages/wethegit-components/src/utilities/spacing/styles/_spacing-utilities.scss
@@ -1,0 +1,13 @@
+// Baseline spacing unit.
+$spacing-unit: 8px;
+
+// Creates a value which is a multiple of the $base-space property.
+@function space-by($multiplier: false) {
+  @if not $multiplier {
+    @return $spacing-unit;
+  } @else if $multiplier == 1 {
+    @return $spacing-unit;
+  } @else {
+    @return $spacing-unit * $multiplier;
+  }
+}

--- a/packages/wethegit-components/src/utilities/spacing/styles/spacing-utilities.stories.mdx
+++ b/packages/wethegit-components/src/utilities/spacing/styles/spacing-utilities.stories.mdx
@@ -1,0 +1,37 @@
+import { Meta } from "@storybook/blocks"
+
+<Meta title="utilities/spacing/styles/spacing-utilities" />
+
+# Spacing utilities
+
+The spacing utility also comes with a Sass function that can be used to get the value of a spacing unit.
+
+It's in this file that you also define the spacing unit, which is used by the function. By default, the spacing unit is `8px`.
+
+## Usage
+
+`@use` the helpers within in a `.scss` stylesheet:
+
+```css filename="utilities/your-component/your-component.module.scss"
+@use "@local/utilities/spacing/styles/spacing-utilities" as *;
+```
+
+## space-by
+
+Signature: `space-by($multiplier)`
+
+`space-by` Receives a number, and returns a spacing unit multiplied by that number.
+
+### Example
+
+```css
+.customComponent {
+  margin-right: space-by(6); // 6 * 8px = 48px
+}
+```
+
+## $spacing-unit
+
+Signature: `$spacing-unit: 8px !default;`
+
+The spacing unit is used by the `space-by` function.


### PR DESCRIPTION
## Description

I forgot to document the available Sass function.

## Solution

Added a section on the spacing docs about the `space-by` function and a whole new docs page about the how to use that function.

## Additional Notes

Also added a section about using utilities without JS
