### PR TITLE
(cli) feature: adds post install messages

### DIFF
--- a/packages/wethegit-components-cli/src/commands/add/index.ts
+++ b/packages/wethegit-components-cli/src/commands/add/index.ts
@@ -15,6 +15,7 @@ import {
   buildDepsTree,
   copyRegistryItems,
   formatRegistryFilesWithPrettier,
+  logDocsUrls,
   promptForComponents,
 } from "./utils"
 
@@ -81,8 +82,13 @@ export async function add(names: string[], options: Options): Promise<void> {
       })
     }
 
-    logger.info("")
+    logger.log("")
+    logger.log("")
     logger.success(`${chalk.green("Success!")} All done!`)
+    logger.log("")
+
+    logDocsUrls(selected)
+
     logger.info("")
   } catch (error) {
     handleError({

--- a/packages/wethegit-components-cli/src/commands/add/utils/index.ts
+++ b/packages/wethegit-components-cli/src/commands/add/utils/index.ts
@@ -1,5 +1,6 @@
 export * from "./build-deps-tree"
 export * from "./copy-registry-items"
 export * from "./format-registry-files-with-prettier"
+export * from "./log-docs-urls"
 export * from "./prompt-for-components"
 export * from "./transform-ts-to-js"

--- a/packages/wethegit-components-cli/src/commands/add/utils/log-docs-urls.ts
+++ b/packages/wethegit-components-cli/src/commands/add/utils/log-docs-urls.ts
@@ -1,0 +1,32 @@
+import chalk from "chalk"
+
+import type { Registry } from "../../../registry-index"
+import { logger } from "../../../utils"
+
+export function logDocsUrls(selected: Registry[]): void {
+  const hasDocs = selected.some((item) => Boolean(item.docsUrl))
+
+  logger.info("Next steps")
+  logger.log(
+    "Check out the documentation, some of these component might require further configuration."
+  )
+
+  if (!hasDocs) {
+    logger.log("https://wethegit.github.io/component-library/")
+  }
+
+  for (const item of selected) {
+    if (!item.docsUrl && !item.postInstallMessages) continue
+
+    logger.log("")
+    logger.info(`${item.name}`)
+    if (item.docsUrl)
+      logger.log(`${chalk.bold("Documentation:")} ${chalk.italic(item.docsUrl)}`)
+
+    if (item.postInstallMessages) {
+      for (const message of item.postInstallMessages) {
+        logger.log(chalk.gray(message))
+      }
+    }
+  }
+}

--- a/packages/wethegit-components-cli/src/registry-index.ts
+++ b/packages/wethegit-components-cli/src/registry-index.ts
@@ -15,6 +15,10 @@ export interface Registry {
   dependencies?: string[]
   /** Should this item appear as an option when running the add command. Default is true  */
   dontShowOnPrompt?: boolean
+  /** Link to the Storybook documentation */
+  docsUrl?: string
+  /** Array of messages to be displayed after adding the component */
+  postInstallMessages?: string[]
 }
 
 export type RegistryIndex = Record<string, Registry>
@@ -54,6 +58,8 @@ const TEXT: Registry = {
   name: "text",
   category: "component",
   localDependencies: [TAG, CLASSNAMES],
+  docsUrl:
+    "https://wethegit.github.io/component-library/?path=/docs/components-text-readme--docs",
 }
 
 const FLEX: Registry = {
@@ -72,30 +78,44 @@ const GRID_LAYOUT: Registry = {
   name: "grid-layout",
   category: "component",
   localDependencies: [FLEX],
+  docsUrl:
+    "https://wethegit.github.io/component-library/?path=/docs/components-grid-layout-readme--docs",
+  postInstallMessages: [
+    "The grid requires a CSS file to work properly. Add the following line to your global styles:",
+    '@import "@local/components/grid-layout/styles/grid-layout.scss";',
+  ],
 }
 
 const IMAGE_GROUP: Registry = {
   name: "image-group",
   category: "component",
   localDependencies: [CLASSNAMES, FIXED_FORWARD_REF, TAG],
+  docsUrl:
+    "https://wethegit.github.io/component-library/?path=/docs/components-image-group-readme--docs",
 }
 
 const VISUALLY_HIDDEN: Registry = {
   name: "visually-hidden",
   category: "component",
   localDependencies: [TAG, CLASSNAMES],
+  docsUrl:
+    "https://wethegit.github.io/component-library/?path=/docs/components-visually-hidden-readme--docs",
 }
 
 const NAVIGATION: Registry = {
   name: "navigation",
   category: "component",
   localDependencies: [FLEX, CLASSNAMES, VISUALLY_HIDDEN, FIXED_FORWARD_REF],
+  docsUrl:
+    "https://wethegit.github.io/component-library/?path=/docs/components-navigation-readme--docs",
 }
 
 const ICON: Registry = {
   name: "icon",
   category: "component",
   localDependencies: [CLASSNAMES],
+  docsUrl:
+    "https://wethegit.github.io/component-library/?path=/docs/components-icon-readme--docs",
 }
 
 const MODAL: Registry = {
@@ -103,6 +123,8 @@ const MODAL: Registry = {
   category: "component",
   localDependencies: [CLASSNAMES],
   dependencies: ["@wethegit/react-modal", "@wethegit/react-hooks"],
+  docsUrl:
+    "https://wethegit.github.io/component-library/?path=/docs/components-modal-readme--docs",
 }
 
 /* INDEX */


### PR DESCRIPTION
## Description

Initial mock for addressing #67 

## Solution

Adds two new properties to the registry:
- `docsUrl`: link to the storybook documentation
- `postInstallMessages`: an array of strings to be displayed together with the documentation link after user added the component

## Screenshots

![Screenshot 2023-12-12 at 3 41 40 PM](https://github.com/wethegit/component-library/assets/1956448/9790437a-9efe-4b1e-bc1f-b84e1b79cc8e)

