### PR TITLE
Ignore stylelint rules in certain scenarios

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
+    "source.fixAll": "explicit"
   },
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/packages/stylelint-config-custom/base.js
+++ b/packages/stylelint-config-custom/base.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: "stylelint-config-standard-scss",
   plugins: ["stylelint-order"],
+  ignoreFiles: ["../wethegit-components/storybook-static/**/*.css"],
   rules: {
     "at-rule-no-unknown": null,
     "function-no-unknown": null,
@@ -21,4 +22,16 @@ module.exports = {
       },
     ],
   },
+  overrides: [
+    {
+      files: [
+        "../wethegit-components/src/utilities/**/*.js",
+        "../wethegit-components/src/utilities/**/*.ts",
+      ],
+      rules: {
+        "order/properties-alphabetical-order": null,
+        "selector-class-pattern": null,
+      },
+    },
+  ],
 }

--- a/packages/wethegit-components/.storybook/styles/global-story-styles.scss
+++ b/packages/wethegit-components/.storybook/styles/global-story-styles.scss
@@ -1,6 +1,6 @@
-@import "@local/styles/global.scss";
-@import "@local/components/grid-layout/styles/grid-layout.scss";
-@import "@local/components/text/styles/text.scss";
+@import "@local/styles/global";
+@import "@local/components/grid-layout/styles/grid-layout";
+@import "@local/components/text/styles/text";
 
 @mixin gutter-highlight($color: blue, $size) {
   box-shadow:
@@ -13,8 +13,8 @@
 }
 
 html {
-  font-size: 16px;
   color: white;
+  font-size: 16px;
 }
 
 h1,
@@ -32,12 +32,12 @@ a {
 }
 
 code {
-  font-family: monospace;
   background: #d8d8d8;
-  padding: 0.1em 0.2em;
   border-radius: 0.25em;
-  font-size: 0.92em;
   color: black;
+  font-family: monospace;
+  font-size: 0.92em;
+  padding: 0.1em 0.2em;
 }
 
 a {
@@ -48,23 +48,22 @@ a {
   @include dashed-outline;
 }
 
-.gutter-visualizer {
+.gutterVisualizer {
   @include dashed-outline;
   @include gutter-highlight(rgb(83 198 82 / 34%), calc(var(--wtc-gutter-width) * 0.5));
 }
 
-.gutter-visualizer--full {
+.gutterVisualizerFull {
   @include gutter-highlight(rgb(83 198 82 / 34%), var(--wtc-gutter-width));
 }
 
-// TODO:
-// THESE ARE TEMPORARY. Remove them once spacing component is set up.
-.child-spacing {
+.childSpacing {
   > * + * {
     margin-top: 2rem !important;
   }
 }
-.child-spacing--less {
+
+.childSpacingLess {
   > * + * {
     margin-top: 1rem !important;
   }

--- a/packages/wethegit-components/.stylelintrc.js
+++ b/packages/wethegit-components/.stylelintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ["stylelint-config-custom/base"]
-};
+  extends: ["stylelint-config-custom/base"],
+}

--- a/packages/wethegit-components/src/components/grid-layout/column/column.stories.tsx
+++ b/packages/wethegit-components/src/components/grid-layout/column/column.stories.tsx
@@ -68,8 +68,8 @@ export const Default: Story = {
 export const GutterVisualizer: Story = {
   name: "Gutter visualizer",
   render: (args) => (
-    <Row className="gutter-visualizer">
-      <Column className="gutter-visualizer">
+    <Row className="gutterVisualizer">
+      <Column className="gutterVisualizer">
         <p>
           The left or right padding on a <code>Row</code> or a <code>Column</code> is
           equivalent to half of a gutter's width, within your flex-layout. As shown here,
@@ -83,7 +83,7 @@ export const GutterVisualizer: Story = {
           content.
         </p>
       </Column>
-      <Column className="gutter-visualizer" {...args}>
+      <Column className="gutterVisualizer" {...args}>
         {howManyColumns(args.span)}
       </Column>
     </Row>
@@ -93,8 +93,8 @@ export const GutterVisualizer: Story = {
 export const NestedColumns: Story = {
   name: "Nested columns",
   render: (args) => (
-    <Row className="gutter-visualizer">
-      <Column className="gutter-visualizer" {...args}>
+    <Row className="gutterVisualizer">
+      <Column className="gutterVisualizer" {...args}>
         <p>
           Nesting columns is easy. Just add another <code>Row</code>, more{" "}
           <code>Column</code> components and don't forget to set the <code>deep</code>{" "}
@@ -102,18 +102,18 @@ export const NestedColumns: Story = {
         </p>
         {howManyColumns(args.span)}
       </Column>
-      <Column className="gutter-visualizer" span={7}>
+      <Column className="gutterVisualizer" span={7}>
         <p>
           This spans <code>7</code> columns
         </p>
-        <Row className="gutter-visualizer">
-          <Column className="gutter-visualizer" deep>
+        <Row className="gutterVisualizer">
+          <Column className="gutterVisualizer" deep>
             <p>
               Notice how the text touches the edge and they don't have an internal
               padding.
             </p>
           </Column>
-          <Column className="gutter-visualizer" deep>
+          <Column className="gutterVisualizer" deep>
             <p>
               Notice how the text touches the edge and they don't have an internal
               padding.

--- a/packages/wethegit-components/src/components/grid-layout/wrapper/wrapper.stories.tsx
+++ b/packages/wethegit-components/src/components/grid-layout/wrapper/wrapper.stories.tsx
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof Wrapper>
 
 export const Default: Story = {
   render: (args) => (
-    <Wrapper className="gutter-visualizer gutter-visualizer--full" {...args}>
+    <Wrapper className="gutterVisualizer gutterVisualizerFull" {...args}>
       <p>
         Tempor anim duis velit ut ea occaecat ullamco tempor elit elit ullamco id pariatur
         quis. Laboris incididunt aute ipsum pariatur. Et sit non et irure laboris

--- a/packages/wethegit-components/src/components/text/text.stories.tsx
+++ b/packages/wethegit-components/src/components/text/text.stories.tsx
@@ -24,13 +24,13 @@ type Story = StoryObj<typeof Text>
  */
 export const Default: Story = {
   render: (args) => (
-    <div className="child-spacing">
+    <div className="childSpacing">
       {/*
         TODO: REMOVE THESE CHILD SPACING CLASSES.
         Use the spacing components or utility class names we build, once they're ready.
       */}
 
-      <div className="child-spacing child-spacing--less">
+      <div className="childSpacing childSpacingLess">
         <Text as="h1" variant="title-1">
           Title 1
         </Text>


### PR DESCRIPTION
# (components) fix: Ignore Stylelint errors for Utilities and Storybook generated files 

## Description
Utility classnames don't need to follow some of our stylelint rules, so this PR disables things like enforcing camel case for those. This is nice because it allows us to have more readable util classes, like `justify-content-lg-space-around`.

This also ignores all stylelint rules for storybook-generated CSS. This was causing hundreds of linting errors.

## Notes
- I've simply ignored all rules for the Storybook static stuff, but…
- I've used stylelint's `overrides` to only disable a couple rules for our Typescript/JavaScript utilities.
- Will add a changeset once we've had some eyes on this PR