### PR TITLE
(docs) fix: wrong install instruction

### DIFF
--- a/packages/wethegit-components/src/index.stories.mdx
+++ b/packages/wethegit-components/src/index.stories.mdx
@@ -21,7 +21,7 @@ Make sure you have **Node.js v18+** installed.
 Install:
 
 ```bash
-npm install -D @wethegit/components-cli
+npm install -D @wethegit/components @wethegit/components-cli
 ```
 
 Initialize the project, this step will create the required directories and install the mandatory dependencies.


### PR DESCRIPTION
## Description

The components are a `peerDependecy` of the CLI, they also MUST be installed. It's one of the fundamental aspects of the library where the CLI and components are de-coupled.