### PR TITLE
[COMP] Flex: fix responsive classnames

### DIFF
--- a/packages/wethegit-components/src/components/flex/flex.module.scss
+++ b/packages/wethegit-components/src/components/flex/flex.module.scss
@@ -65,17 +65,17 @@
 @include breakpoint-classnames;
 
 @media #{$md-up} {
-  @include breakpoint-classnames(md);
+  @include breakpoint-classnames(-md);
 }
 
 @media #{$lg-up} {
-  @include breakpoint-classnames(lg);
+  @include breakpoint-classnames(-lg);
 }
 
 @media #{$xl-up} {
-  @include breakpoint-classnames(xl);
+  @include breakpoint-classnames(-xl);
 }
 
 @media #{$xxl-up} {
-  @include breakpoint-classnames(xxl);
+  @include breakpoint-classnames(-xxl);
 }


### PR DESCRIPTION
## Description

Adds a missing dash to the breakpoint classnames. Fixes #172 

## Additional Notes

As we discussed in #172, we ought to update the `buildBreakpointClassnames` utility to _not only_ honor the large-up breakpoints, as that is a specific grid-layout opinion. The `<Flex>` component, for example, should be able to receive specific values for small and medium as well. I am making a separate issue for that though!

## Screenshots

This screencap illustrates the `justify` prop using the following responsive options:

```jsx
<Flex justify={{ md: "flex-start", lg: "center", xxl: "flex-end" }}>
  <span>I</span>
  <span>am</span>
  <span>so</span>
  <span>cool</span>
</Flex>
```

https://github.com/wethegit/component-library/assets/30575213/63376902-da97-4607-a698-5d8c186cbcd2


