### PR TITLE
release v3.0.6

### DIFF
--- a/.changeset/six-zoos-check.md
+++ b/.changeset/six-zoos-check.md
@@ -1,0 +1,7 @@
+---
+"@wethegit/components-cli": patch
+"@wethegit/components": patch
+"tsconfig": patch
+---
+
+Fixes various issues on the Flex, BackToTop, spacing, and Text components. Creates a useBreakpoints hook, and refactors BreakpointSnipe to use it.

--- a/packages/tsconfig/react-library.json
+++ b/packages/tsconfig/react-library.json
@@ -4,7 +4,7 @@
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "lib": ["dom", "ES2015"],
+    "lib": ["dom", "esnext"],
     "module": "ESNext",
     "target": "es6"
   }

--- a/packages/wethegit-components-cli/src/registry-index.ts
+++ b/packages/wethegit-components-cli/src/registry-index.ts
@@ -80,7 +80,7 @@ const TAG: Registry = {
 const TEXT: Registry = {
   name: "text",
   category: "component",
-  localDependencies: [TAG, CLASSNAMES, FIXED_FORWARD_REF],
+  localDependencies: [BUILD_BREAKPOINT_CLASSNAMES, CLASSNAMES, FIXED_FORWARD_REF, TAG],
   docsUrl:
     "https://wethegit.github.io/component-library/?path=/docs/components-text-readme--overview",
   postInstallMessages: [

--- a/packages/wethegit-components-cli/src/registry-index.ts
+++ b/packages/wethegit-components-cli/src/registry-index.ts
@@ -33,6 +33,12 @@ const BREAKPOINTS_TYPE: Registry = {
   dontShowOnPrompt: true,
 }
 
+/* HOOKS */
+const USE_BREAKPOINTS: Registry = {
+  name: "use-breakpoints",
+  category: "hook",
+}
+
 /* UTILITIES */
 const FIXED_FORWARD_REF: Registry = {
   name: "fixed-forward-ref",
@@ -175,7 +181,7 @@ const VISUALLY_HIDDEN_LINKS: Registry = {
 const BREAKPOINT_SNIPE: Registry = {
   name: "breakpoint-snipe",
   category: "component",
-  localDependencies: [CLASSNAMES],
+  localDependencies: [CLASSNAMES, USE_BREAKPOINTS],
 }
 
 const BACK_TO_TOP: Registry = {
@@ -207,5 +213,7 @@ export const REGISTRY_INDEX: RegistryIndex = {
   [COLOR.name]: COLOR,
   [SPACING.name]: SPACING,
   [VISIBILITY.name]: VISIBILITY,
+
+  [USE_BREAKPOINTS.name]: USE_BREAKPOINTS,
 }
 /* END REGISTRY INDEX */

--- a/packages/wethegit-components/src/components/back-to-top/back-to-top.module.scss
+++ b/packages/wethegit-components/src/components/back-to-top/back-to-top.module.scss
@@ -1,12 +1,11 @@
-@use "@local/utilities/color/styles/color-utilities" as *;
 @use "@local/styles/animation/animation-utilities" as *;
 
 .button {
   --scale: 1;
 
-  background-color: get-color("black");
+  background-color: #000;
   bottom: 1rem;
-  color: get-color("white");
+  color: #fff;
   opacity: 0;
   padding: 1rem;
   position: fixed;

--- a/packages/wethegit-components/src/components/back-to-top/back-to-top.tsx
+++ b/packages/wethegit-components/src/components/back-to-top/back-to-top.tsx
@@ -42,7 +42,7 @@ export function BackToTop({
 }: BackToTopProps): JSX.Element {
   const buttonRef = useRef<HTMLButtonElement>(null)
   const { prefersReducedMotion } = useUserPrefs()
-  const [setReferenceRef, referenceIsInView] = useInView(1, false, false)
+  const [setReferenceRef, referenceIsInView] = useInView(0, false, false)
 
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -54,10 +54,10 @@ export function BackToTop({
 
       const position = window.scrollY
       const duration = prefersReducedMotion ? 0 : getDuration(position, pixelsPerSecond)
-      let starttime: null | number = null
+      let starttime: number | null = null
 
       const animate = (delta: number) => {
-        if (starttime === null) starttime = 0
+        if (starttime === null) starttime = delta
 
         const playHead = clamp(0, 1, (delta - starttime) / duration)
         const easedPlayHead = easingFunction
@@ -76,7 +76,14 @@ export function BackToTop({
 
       requestAnimationFrame(animate)
     },
-    [prefersReducedMotion]
+    [
+      easingFunction,
+      focusOnCompleteCssSelector,
+      onComplete,
+      pixelsPerSecond,
+      prefersReducedMotion,
+      props.onClick,
+    ]
   )
 
   return (
@@ -92,7 +99,7 @@ export function BackToTop({
         ref={buttonRef}
         className={classnames([
           styles.button,
-          (!referenceIsInView || revealThreshold.startsWith("0")) && styles.buttonShown,
+          (revealThreshold.startsWith("0") || !referenceIsInView) && styles.buttonShown,
           className,
         ])}
         onClick={handleClick}

--- a/packages/wethegit-components/src/components/breakpoint-snipe/breakpoint-snipe.module.scss
+++ b/packages/wethegit-components/src/components/breakpoint-snipe/breakpoint-snipe.module.scss
@@ -1,5 +1,3 @@
-@use "@local/styles/breakpoints/breakpoints-variables" as *;
-
 .breakpointSnipe {
   align-items: center;
   aspect-ratio: 1/1;
@@ -12,45 +10,9 @@
   position: fixed;
   right: 0;
   width: 40px;
-
-  &::before {
-    content: "sm";
-  }
 }
 
 .breakpointSnipeDark {
   background-color: black;
   color: white;
-}
-
-@media #{$md-up} {
-  .breakpointSnipe {
-    &::before {
-      content: "md";
-    }
-  }
-}
-
-@media #{$lg-up} {
-  .breakpointSnipe {
-    &::before {
-      content: "lg";
-    }
-  }
-}
-
-@media #{$xl-up} {
-  .breakpointSnipe {
-    &::before {
-      content: "xl";
-    }
-  }
-}
-
-@media #{$xxl-up} {
-  .breakpointSnipe {
-    &::before {
-      content: "xxl";
-    }
-  }
 }

--- a/packages/wethegit-components/src/components/breakpoint-snipe/breakpoint-snipe.tsx
+++ b/packages/wethegit-components/src/components/breakpoint-snipe/breakpoint-snipe.tsx
@@ -1,3 +1,4 @@
+import { useBreakpoints } from "@local/hooks"
 import { classnames } from "@local/utilities"
 
 import styles from "./breakpoint-snipe.module.scss"
@@ -19,6 +20,8 @@ export function BreakpointSnipe({
   className,
   ...props
 }: BreakpointSnipeProps) {
+  const { breakpoint } = useBreakpoints()
+
   return (
     <div
       className={classnames([
@@ -28,6 +31,8 @@ export function BreakpointSnipe({
       ])}
       {...props}
       aria-hidden="true"
-    />
+    >
+      {breakpoint}
+    </div>
   )
 }

--- a/packages/wethegit-components/src/components/flex/flex.module.scss
+++ b/packages/wethegit-components/src/components/flex/flex.module.scss
@@ -62,7 +62,7 @@
   display: flex;
 }
 
-@include breakpoint-classnames;
+@include breakpoint-classnames(-sm);
 
 @media #{$md-up} {
   @include breakpoint-classnames(-md);

--- a/packages/wethegit-components/src/components/flex/flex.module.scss
+++ b/packages/wethegit-components/src/components/flex/flex.module.scss
@@ -65,17 +65,17 @@
 @include breakpoint-classnames;
 
 @media #{$md-up} {
-  @include breakpoint-classnames(md);
+  @include breakpoint-classnames(-md);
 }
 
 @media #{$lg-up} {
-  @include breakpoint-classnames(lg);
+  @include breakpoint-classnames(-lg);
 }
 
 @media #{$xl-up} {
-  @include breakpoint-classnames(xl);
+  @include breakpoint-classnames(-xl);
 }
 
 @media #{$xxl-up} {
-  @include breakpoint-classnames(xxl);
+  @include breakpoint-classnames(-xxl);
 }

--- a/packages/wethegit-components/src/components/flex/flex.tsx
+++ b/packages/wethegit-components/src/components/flex/flex.tsx
@@ -8,7 +8,7 @@ import styles from "./flex.module.scss"
 
 export type FlexAlign = "flex-start" | "center" | "flex-end" | "baseline" | "stretch"
 
-export type AlignBreakpoints = Partial<Omit<Breakpoints<FlexAlign>, "sm">>
+export type AlignBreakpoints = Partial<Breakpoints<FlexAlign>>
 
 export type FlexJustify =
   | "flex-start"
@@ -17,9 +17,9 @@ export type FlexJustify =
   | "space-between"
   | "space-around"
 
-export type JustifyBreakpoints = Partial<Omit<Breakpoints<FlexJustify>, "sm">>
+export type JustifyBreakpoints = Partial<Breakpoints<FlexJustify>>
 
-export type BooleanBreakpoints = Partial<Omit<Breakpoints<boolean>, "sm">>
+export type BooleanBreakpoints = Partial<Breakpoints<boolean>>
 
 export type FlexProps<TAs extends ElementType> = TagProps<TAs> & {
   /**

--- a/packages/wethegit-components/src/components/grid-layout/column/column.module.scss
+++ b/packages/wethegit-components/src/components/grid-layout/column/column.module.scss
@@ -27,7 +27,7 @@
 }
 
 @media #{$md-up} {
-  @include make-column-classnames;
+  @include make-column-classnames(md);
 }
 
 @media #{$lg-up} {

--- a/packages/wethegit-components/src/components/text/styles/_text-utilities.scss
+++ b/packages/wethegit-components/src/components/text/styles/_text-utilities.scss
@@ -2,11 +2,11 @@
 
 // Calculates the rem value of the provided unitelss pixel value input.
 // This assumes 16px as a base.
-@function calc-rem($value, $base: 16) {
-  @return math.div($value, $base) * 1rem;
+@function calc-rem($value) {
+  @return calc(#{$value} / var(--wtc-base-rem-size) * 1rem);
 }
 
 // This is a variation of the above, which accepts a CSS custom property instead of a number.
-@function calc-rem-css-var($css-var, $base: 16) {
-  @return calc(var($css-var) / 16 * 1rem);
+@function calc-rem-css-var($css-var) {
+  @return calc(var($css-var) / var(--wtc-base-rem-size) * 1rem);
 }

--- a/packages/wethegit-components/src/components/text/styles/text-utilities.stories.mdx
+++ b/packages/wethegit-components/src/components/text/styles/text-utilities.stories.mdx
@@ -19,9 +19,9 @@ import { Meta } from "@storybook/blocks"
 
 ## calc-rem
 
-Signature: `calc-rem(unitless-pixel-value, <base-unitless-size> = 16)`
+Signature: `calc-rem(unitless-pixel-value)`
 
-`calc-rem` Receives a unitless pixel value, and converts it into a `rem` value. This is accomplished by dividing the value by 16, which is the default font size in most browsers.
+`calc-rem` Receives a unitless pixel value, and converts it into a `rem` value. This is accomplished by dividing the value by 16, which is the default font size in most browsers. That `16` can be manipulated via the root-level CSS custom property, `--wtc-base-rem-size`, although the need for this is uncommon.
 
 ### Example
 

--- a/packages/wethegit-components/src/components/text/styles/text.scss
+++ b/packages/wethegit-components/src/components/text/styles/text.scss
@@ -1,6 +1,13 @@
 @use "@local/styles/breakpoints/breakpoints-variables" as *;
 
 :root {
+  // fonts
+  --wtc-font-family-heading: sans-serif;
+  --wtc-font-family-body: sans-serif;
+
+  // pixel value equivalent to 1rem — this will rarely change
+  --wtc-base-rem-size: 16;
+
   // font sizes
   --wtc-font-size-title-1: 42;
   --wtc-font-size-title-2: 33;

--- a/packages/wethegit-components/src/components/text/styles/text.stories.mdx
+++ b/packages/wethegit-components/src/components/text/styles/text.stories.mdx
@@ -4,7 +4,7 @@ import { Meta } from "@storybook/blocks"
 
 # Text Styles
 
-This file contains the CSS variables that are used to customize the text styles and must be added to your global stylesheet for the `<Text>` component to work properly.
+This file contains information about the CSS variables that are used to customize the text styles. These variables must be added to your global stylesheet for the `<Text>` component to work properly.
 
 - [Font size](#font-size)
 - [Font weight](#font-weight)

--- a/packages/wethegit-components/src/components/text/text.module.scss
+++ b/packages/wethegit-components/src/components/text/text.module.scss
@@ -1,30 +1,51 @@
+@use "@local/styles/breakpoints/breakpoints-variables" as *;
 @use "./styles/text-utilities" as *;
 
 $alignments: start, center, end, justify;
 $variants: "title-1", "title-2", "title-3", "title-4", "title-5", "title-6", "body",
   "body-smaller", "body-larger", "body-legal";
 $weights: "light", "regular", "medium", "semibold", "bold", "black";
+$wraps: wrap, nowrap, balance, pretty;
+
+@mixin alignment-classnames($prefix: "") {
+  @each $a in $alignments {
+    .align#{$prefix}-#{$a} {
+      text-align: $a;
+    }
+  }
+}
 
 .text {
   margin: 0;
+  text-wrap: pretty;
 }
 
 .textHeading {
+  font-family: var(--wtc-font-family-heading);
+
   // This default font weight can be overwritten by the `weight` prop.
   font-weight: var(--wtc-font-weight-bold);
   line-height: var(--wtc-line-height-heading);
 }
 
 .textBody {
+  font-family: var(--wtc-font-family-body);
+
   // This default font weight can be overwritten by the `weight` prop.
   font-weight: var(--wtc-font-weight-regular);
   line-height: var(--wtc-line-height-body);
 }
 
-@each $a in $alignments {
-  .align-#{$a} {
-    text-align: $a;
-  }
+.noWrap {
+  white-space: nowrap;
+}
+
+.wrapNormal {
+  text-wrap: wrap;
+}
+
+.wrapBalance {
+  text-wrap: balance;
 }
 
 @each $v in $variants {
@@ -39,6 +60,26 @@ $weights: "light", "regular", "medium", "semibold", "bold", "black";
   }
 }
 
-.noWrap {
-  white-space: nowrap;
+@each $wrap in $wraps {
+  .wrap-#{$wrap} {
+    text-wrap: $wrap;
+  }
+}
+
+@include alignment-classnames(-sm);
+
+@media #{$md-up} {
+  @include alignment-classnames(-md);
+}
+
+@media #{$lg-up} {
+  @include alignment-classnames(-lg);
+}
+
+@media #{$xl-up} {
+  @include alignment-classnames(-xl);
+}
+
+@media #{$xxl-up} {
+  @include alignment-classnames(-xxl);
 }

--- a/packages/wethegit-components/src/components/text/text.tsx
+++ b/packages/wethegit-components/src/components/text/text.tsx
@@ -1,12 +1,13 @@
 import { Tag } from "@local/components/tag"
 import type { TagProps } from "@local/components/tag"
-import { classnames } from "@local/utilities"
+import { buildBreakpointClassnames, classnames } from "@local/utilities"
 
 import styles from "./text.module.scss"
 
 const DEFAULT_ELEMENT = "p"
 
 type TextAlign = "start" | "center" | "end" | "justify"
+type TextAlignBreakpoints = Partial<Breakpoints<TextAlign>>
 
 type TextVariant =
   | "title-1"
@@ -22,11 +23,13 @@ type TextVariant =
 
 type TextWeight = "light" | "regular" | "medium" | "semibold" | "bold" | "black"
 
+type TextWrap = "wrap" | "nowrap" | "balance" | "pretty"
+
 export type TextProps<TAs extends React.ElementType> = TagProps<TAs> & {
   /**
    * Specifies the inline text alignment. If omitted, inherits the parent alignment.
    */
-  align?: TextAlign
+  align?: TextAlign | TextAlignBreakpoints
   /**
    * The _visual_ hierarchy of the text. This is not the same as the semantic hierarchy.
    */
@@ -36,9 +39,9 @@ export type TextProps<TAs extends React.ElementType> = TagProps<TAs> & {
    */
   weight?: TextWeight
   /**
-   * Use default text-wrapping.
+   * Specify the text-wrapping algorithm. If omitted, the base .text class decalres it as "pretty".
    */
-  wordWrap?: boolean
+  wrap?: TextWrap
   className?: string
 }
 
@@ -46,7 +49,7 @@ export function Text<TAs extends React.ElementType = typeof DEFAULT_ELEMENT>({
   align,
   variant = "body",
   weight,
-  wordWrap = true,
+  wrap,
   className,
   ...props
 }: TextProps<TAs>): JSX.Element {
@@ -55,10 +58,10 @@ export function Text<TAs extends React.ElementType = typeof DEFAULT_ELEMENT>({
   const classes = classnames([
     styles.text,
     styles[variant.startsWith("title-") ? "textHeading" : "textBody"],
-    align && styles[`align-${align}`],
+    align && buildBreakpointClassnames<TextAlign>(align, styles, "align"),
     styles[`variant-${variant}`],
     weight && styles[`weight-${weight}`],
-    !wordWrap && styles.noWrap,
+    wrap && styles[`wrap-${wrap}`],
     className,
   ])
 

--- a/packages/wethegit-components/src/hooks/index.ts
+++ b/packages/wethegit-components/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./use-breakpoints"

--- a/packages/wethegit-components/src/hooks/use-breakpoints/index.ts
+++ b/packages/wethegit-components/src/hooks/use-breakpoints/index.ts
@@ -1,0 +1,1 @@
+export { useBreakpoints } from "./use-breakpoints"

--- a/packages/wethegit-components/src/hooks/use-breakpoints/readme.stories.mdx
+++ b/packages/wethegit-components/src/hooks/use-breakpoints/readme.stories.mdx
@@ -1,0 +1,35 @@
+import { Meta, Markdown } from "@storybook/blocks"
+
+<Meta title="hooks/useBreakpoints" />
+
+# useBreakpoints
+
+Location: `@local/hooks/use-breakpoints.ts`
+
+`useBreakpoints` is a custom React hook that returns information about the current media-query/breakpoint. See [Breakpoint docs](/docs/styles-breakpoints-breakpoints-variables--overview). The hook comes pre-loaded with the component library, and is added to your project upon running the `@wethegit/components-cli init` command.
+
+## Usage example
+
+```jsx
+import { useBreakpoints } from "@local/hooks"
+
+function YourComponent() {
+  const { breakpoint } = useBreakpoints()
+
+  return <h1>{breakpoint === "sm" ? 🐁 : 🐘}</h1>
+}
+```
+
+## Return value
+
+<Markdown>
+  {`
+| property   | type                          | description                                                               |
+| ---------- | ----------------------------- | ------------------------------------------------------------------------- |
+| breakpoint | "sm", "md", "lg", "xl", "xxl" | A string representation of the current breakpoint.                        |
+| mdUp       | boolean, undefined            | Whether or not the current breakpoint can be considered "medium-and-up".  |
+| lgUp       | boolean, undefined            | Whether or not the current breakpoint can be considered "large-and-up".   |
+| xlUp       | boolean, undefined            | Whether or not the current breakpoint can be considered "xlarge-and-up".  |
+| xxlUp      | boolean, undefined            | Whether or not the current breakpoint can be considered "xxlarge-and-up". |
+`}
+</Markdown>

--- a/packages/wethegit-components/src/hooks/use-breakpoints/use-breakpoints.module.scss
+++ b/packages/wethegit-components/src/hooks/use-breakpoints/use-breakpoints.module.scss
@@ -1,0 +1,12 @@
+/* stylelint-disable selector-pseudo-class-no-unknown */
+/* stylelint-disable property-no-unknown */
+
+@import "@local/styles/breakpoints/breakpoints-variables";
+
+:export {
+  lg: $lg-only;
+  md: $md-only;
+  sm: $sm-only;
+  xl: $xl-only;
+  xxl: $xxl-up;
+}

--- a/packages/wethegit-components/src/hooks/use-breakpoints/use-breakpoints.ts
+++ b/packages/wethegit-components/src/hooks/use-breakpoints/use-breakpoints.ts
@@ -1,0 +1,52 @@
+import { useEffect, useMemo, useState } from "react"
+
+import breakpointSettings from "./use-breakpoints.module.scss"
+
+const BREAKPOINTS: [Breakpoint, string][] = Object.entries(breakpointSettings).map(
+  ([key, val]) => [key as Breakpoint, val.replaceAll('"', "")]
+)
+
+export function useBreakpoints() {
+  const [breakpoint, setBreakpoint] = useState<Breakpoint | undefined>("sm")
+
+  useEffect(() => {
+    let resizeTimer: ReturnType<typeof setTimeout>
+
+    function onResize() {
+      clearTimeout(resizeTimer)
+      resizeTimer = setTimeout(() => {
+        setBreakpoint(BREAKPOINTS.find((bp) => window.matchMedia(bp[1]).matches)?.[0])
+      }, 200)
+    }
+
+    onResize()
+
+    window.addEventListener("resize", onResize)
+
+    return () => {
+      clearTimeout(resizeTimer)
+      window.removeEventListener("resize", onResize)
+    }
+  }, [])
+
+  const breakpointData = useMemo(() => {
+    let xxlUp, xlUp, lgUp, mdUp
+
+    if (breakpoint) {
+      xxlUp = breakpoint === "xxl"
+      xlUp = xxlUp || breakpoint === "xl"
+      lgUp = xlUp || breakpoint === "lg"
+      mdUp = lgUp || breakpoint === "md"
+    }
+
+    return {
+      breakpoint,
+      mdUp,
+      lgUp,
+      xlUp,
+      xxlUp,
+    }
+  }, [breakpoint])
+
+  return breakpointData
+}

--- a/packages/wethegit-components/src/styles/reset.scss
+++ b/packages/wethegit-components/src/styles/reset.scss
@@ -19,11 +19,6 @@ dd {
   margin-block-end: 0;
 }
 
-/* Set core root defaults */
-html:focus-within {
-  scroll-behavior: smooth;
-}
-
 /* Set core body defaults */
 body {
   -webkit-font-smoothing: antialiased;

--- a/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.stories.mdx
+++ b/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.stories.mdx
@@ -8,20 +8,21 @@ The `buildBreakpointClassnames` function is designed to generate class names bas
 
 ## Parameters
 
-#### `prop: T | Partial<Omit<Breakpoints<T>, "sm">> | undefined`
+#### `prop: T | Partial<Breakpoints<T>> | undefined`
 
-- The `prop` parameter represents the breakpoint value or an object containing specific breakpoints (md, lg, xl, xxl).
+- The `prop` parameter represents the breakpoint value or an object containing specific breakpoints (sm, md, lg, xl, xxl).
 - It accepts a generic type `T` which can be `string`, `number`, or `boolean`.
-- If `prop` is an object, it can have properties for medium (md), large (lg), extra-large (xl), and double extra-large (xxl) breakpoints.
+- If `prop` is an object, it can have properties for small (sm), medium (md), large (lg), extra-large (xl), and double extra-large (xxl) breakpoints.
 
 #### `styles: Record<string, string>`
 
 - Default CSS modules `styles`. It is used to generate the breakpoint class names and should contain the following classes:
 
-1. `md`: `${styleName}-${value}`
-2. `lg`: `${styleName}-lg-${value}`
-3. `xl`: `${styleName}-xl-${value}`
-4. `xxl`: `${styleName}-xxl-${value}`
+1. `sm`: `${styleName}-${value}`
+2. `md`: `${styleName}-md-${value}`
+3. `lg`: `${styleName}-lg-${value}`
+4. `xl`: `${styleName}-xl-${value}`
+5. `xxl`: `${styleName}-xxl-${value}`
 
 #### `styleName: string`
 
@@ -38,7 +39,7 @@ import { buildBreakpointClassnames } from "path/to/buildBreakpointClassnames"
 import styles from "path/to/styles.module.css"
 
 const breakpointClasses = buildBreakpointClassnames(
-  { md: 2, lg: 3, xl: 4, xxl: 5 },
+  { sm: 1, md: 2, lg: 3, xl: 4, xxl: 5 },
   styles,
   "container"
 )
@@ -47,5 +48,11 @@ const breakpointClasses = buildBreakpointClassnames(
 The above example will return the following array:
 
 ```typescript
-const result = ["container-2", "container-lg-3", "container-xl-4", "container-xxl-5"]
+const result = [
+  "container-1",
+  "container-md-2",
+  "container-lg-3",
+  "container-xl-4",
+  "container-xxl-5",
+]
 ```

--- a/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.ts
+++ b/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.ts
@@ -1,16 +1,17 @@
 import type { ClassnamesProps } from "../classnames"
 
 export function buildBreakpointClassnames<T extends string | number | boolean>(
-  prop: T | Partial<Omit<Breakpoints<T>, "sm">> | undefined,
+  prop: T | Partial<Breakpoints<T>> | undefined,
   styles: Record<string, string>,
   styleName: string
 ): ClassnamesProps {
   const allClassnames: ClassnamesProps = []
 
   if (typeof prop === "object") {
-    const { md, lg, xl, xxl } = prop
+    const { sm, md, lg, xl, xxl } = prop
 
-    if (md) allClassnames.push(styles[`${styleName}-${md}`])
+    if (sm) allClassnames.push(styles[`${styleName}-sm-${sm}`])
+    if (md) allClassnames.push(styles[`${styleName}-md-${md}`])
     if (lg) allClassnames.push(styles[`${styleName}-lg-${lg}`])
     if (xl) allClassnames.push(styles[`${styleName}-xl-${xl}`])
     if (xxl) allClassnames.push(styles[`${styleName}-xxl-${xxl}`])

--- a/packages/wethegit-components/src/utilities/color/color.ts
+++ b/packages/wethegit-components/src/utilities/color/color.ts
@@ -2,7 +2,7 @@ import styles from "./color.module.scss"
 
 const colorNames = ["black", "white"] as const
 
-type ColorNames = (typeof colorNames)[number]
+export type ColorNames = (typeof colorNames)[number]
 
 type ColorNamesToStyles = Record<ColorNames, string>
 

--- a/packages/wethegit-components/src/utilities/spacing/spacing.ts
+++ b/packages/wethegit-components/src/utilities/spacing/spacing.ts
@@ -59,15 +59,19 @@ for (const bp of BREAKPOINTS) {
       // e.g. spacing.margin[1]
       spacing[prop][i] = styles[`${prop}-${i}`]
 
+      // base spacing, per breakpoint
+      // e.g. spacing.xl.margin[2]
+      spacing[bp][prop] ||= {} as Spacing["md"]["margin"]
+      spacing[bp][prop][i] = styles[`${prop}-${bp}-${i}`]
+
       for (const dir of directions) {
         // base directional spacing
         // e.g. spacing.margin.left[1]
         spacing[prop][dir] ||= {} as Spacing["margin"]["left"]
         spacing[prop][dir][i] = styles[`${prop}-${dir}-${i}`]
 
-        // breakpoint spacing
+        // breakpoint directional spacing
         // e.g. spacing.md.margin.left[1]
-        spacing[bp][prop] ||= {} as Spacing["md"]["margin"]
         spacing[bp][prop][dir] ||= {} as Spacing["md"]["margin"]["left"]
         spacing[bp][prop][dir][i] = styles[`${prop}-${dir}-${bp}-${i}`]
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11497,16 +11497,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11610,14 +11601,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12663,7 +12647,7 @@ vfile@^5.0.0, vfile@^5.1.0, vfile@^5.3.7:
     unist-util-stringify-position "^3.0.0"
     vfile-message "^3.0.0"
 
-vite@^4.4.9:
+vite@^4.5.3:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/vite/-/vite-4.5.3.tgz#d88a4529ea58bae97294c7e2e6f0eab39a50fb1a"
   integrity sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==
@@ -12847,7 +12831,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12860,15 +12844,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# release v3.0.6

## What was added?
- Fix `Flex` responsive classnames
  - Feature PR: #181 
  - Closes #172 
  - Closes #100 
- Fix: Removes smooth scroll CSS from html tag
  - Feature PR: #184 
  - Closes #155 
- Fix: Add missing breakpoint objects to `spacing` utility
  - Feature PR: #188 
  - Closes #173 
- Fix: `BackToTop` various issues
  - Bugfix PR: #187
- Feature: `Text`: add CSS custom properties for font-family, base-rem-size. Add text-wrapping `wrap` prop to replace `wordWrap` boolean; default to `pretty`.
  - Closes #180 
  - closes #162 
  - closes #153 
- Feature: `Color` utility: expose `ColorNames` type
  - Closes #156 
- Feature: Adds `useBreakpoints` React hook; refactor `<BreakpointSnipe>` to use this as well
  - Closes #148 

## Notes
Please feel free to add PATCH fixes and updates to this release while it's open. Thanks.