### PR TITLE
[COMP] feature: allow small ("sm") breakpoint support for `buildBreakpointClassnames`

### DIFF
--- a/packages/wethegit-components/src/components/flex/flex.module.scss
+++ b/packages/wethegit-components/src/components/flex/flex.module.scss
@@ -62,7 +62,7 @@
   display: flex;
 }
 
-@include breakpoint-classnames;
+@include breakpoint-classnames(-sm);
 
 @media #{$md-up} {
   @include breakpoint-classnames(-md);

--- a/packages/wethegit-components/src/components/flex/flex.module.scss
+++ b/packages/wethegit-components/src/components/flex/flex.module.scss
@@ -65,17 +65,17 @@
 @include breakpoint-classnames;
 
 @media #{$md-up} {
-  @include breakpoint-classnames(md);
+  @include breakpoint-classnames(-md);
 }
 
 @media #{$lg-up} {
-  @include breakpoint-classnames(lg);
+  @include breakpoint-classnames(-lg);
 }
 
 @media #{$xl-up} {
-  @include breakpoint-classnames(xl);
+  @include breakpoint-classnames(-xl);
 }
 
 @media #{$xxl-up} {
-  @include breakpoint-classnames(xxl);
+  @include breakpoint-classnames(-xxl);
 }

--- a/packages/wethegit-components/src/components/flex/flex.tsx
+++ b/packages/wethegit-components/src/components/flex/flex.tsx
@@ -8,7 +8,7 @@ import styles from "./flex.module.scss"
 
 export type FlexAlign = "flex-start" | "center" | "flex-end" | "baseline" | "stretch"
 
-export type AlignBreakpoints = Partial<Omit<Breakpoints<FlexAlign>, "sm">>
+export type AlignBreakpoints = Partial<Breakpoints<FlexAlign>>
 
 export type FlexJustify =
   | "flex-start"
@@ -17,9 +17,9 @@ export type FlexJustify =
   | "space-between"
   | "space-around"
 
-export type JustifyBreakpoints = Partial<Omit<Breakpoints<FlexJustify>, "sm">>
+export type JustifyBreakpoints = Partial<Breakpoints<FlexJustify>>
 
-export type BooleanBreakpoints = Partial<Omit<Breakpoints<boolean>, "sm">>
+export type BooleanBreakpoints = Partial<Breakpoints<boolean>>
 
 export type FlexProps<TAs extends ElementType> = TagProps<TAs> & {
   /**

--- a/packages/wethegit-components/src/components/grid-layout/column/column.module.scss
+++ b/packages/wethegit-components/src/components/grid-layout/column/column.module.scss
@@ -27,7 +27,7 @@
 }
 
 @media #{$md-up} {
-  @include make-column-classnames;
+  @include make-column-classnames(md);
 }
 
 @media #{$lg-up} {

--- a/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.stories.mdx
+++ b/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.stories.mdx
@@ -8,20 +8,21 @@ The `buildBreakpointClassnames` function is designed to generate class names bas
 
 ## Parameters
 
-#### `prop: T | Partial<Omit<Breakpoints<T>, "sm">> | undefined`
+#### `prop: T | Partial<Breakpoints<T>> | undefined`
 
-- The `prop` parameter represents the breakpoint value or an object containing specific breakpoints (md, lg, xl, xxl).
+- The `prop` parameter represents the breakpoint value or an object containing specific breakpoints (sm, md, lg, xl, xxl).
 - It accepts a generic type `T` which can be `string`, `number`, or `boolean`.
-- If `prop` is an object, it can have properties for medium (md), large (lg), extra-large (xl), and double extra-large (xxl) breakpoints.
+- If `prop` is an object, it can have properties for small (sm), medium (md), large (lg), extra-large (xl), and double extra-large (xxl) breakpoints.
 
 #### `styles: Record<string, string>`
 
 - Default CSS modules `styles`. It is used to generate the breakpoint class names and should contain the following classes:
 
-1. `md`: `${styleName}-${value}`
-2. `lg`: `${styleName}-lg-${value}`
-3. `xl`: `${styleName}-xl-${value}`
-4. `xxl`: `${styleName}-xxl-${value}`
+1. `sm`: `${styleName}-${value}`
+2. `md`: `${styleName}-md-${value}`
+3. `lg`: `${styleName}-lg-${value}`
+4. `xl`: `${styleName}-xl-${value}`
+5. `xxl`: `${styleName}-xxl-${value}`
 
 #### `styleName: string`
 
@@ -38,7 +39,7 @@ import { buildBreakpointClassnames } from "path/to/buildBreakpointClassnames"
 import styles from "path/to/styles.module.css"
 
 const breakpointClasses = buildBreakpointClassnames(
-  { md: 2, lg: 3, xl: 4, xxl: 5 },
+  { sm: 1, md: 2, lg: 3, xl: 4, xxl: 5 },
   styles,
   "container"
 )
@@ -47,5 +48,11 @@ const breakpointClasses = buildBreakpointClassnames(
 The above example will return the following array:
 
 ```typescript
-const result = ["container-2", "container-lg-3", "container-xl-4", "container-xxl-5"]
+const result = [
+  "container-1",
+  "container-md-2",
+  "container-lg-3",
+  "container-xl-4",
+  "container-xxl-5",
+]
 ```

--- a/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.ts
+++ b/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.ts
@@ -10,7 +10,7 @@ export function buildBreakpointClassnames<T extends string | number | boolean>(
   if (typeof prop === "object") {
     const { sm, md, lg, xl, xxl } = prop
 
-    if (sm) allClassnames.push(styles[`${styleName}-${sm}`])
+    if (sm) allClassnames.push(styles[`${styleName}-sm-${sm}`])
     if (md) allClassnames.push(styles[`${styleName}-md-${md}`])
     if (lg) allClassnames.push(styles[`${styleName}-lg-${lg}`])
     if (xl) allClassnames.push(styles[`${styleName}-xl-${xl}`])

--- a/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.ts
+++ b/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.ts
@@ -1,16 +1,19 @@
 import type { ClassnamesProps } from "../classnames"
 
 export function buildBreakpointClassnames<T extends string | number | boolean>(
-  prop: T | Partial<Omit<Breakpoints<T>, "sm">> | undefined,
+  prop: T | Partial<Breakpoints<T>> | undefined,
   styles: Record<string, string>,
   styleName: string
 ): ClassnamesProps {
   const allClassnames: ClassnamesProps = []
 
   if (typeof prop === "object") {
-    const { md, lg, xl, xxl } = prop
+    const { sm, md, lg, xl, xxl } = prop
 
-    if (md) allClassnames.push(styles[`${styleName}-${md}`])
+    const mediumPrefix = sm ? "md-" : ""
+
+    if (sm) allClassnames.push(styles[`${styleName}-${sm}`])
+    if (md) allClassnames.push(styles[`${styleName}-${mediumPrefix}${md}`])
     if (lg) allClassnames.push(styles[`${styleName}-lg-${lg}`])
     if (xl) allClassnames.push(styles[`${styleName}-xl-${xl}`])
     if (xxl) allClassnames.push(styles[`${styleName}-xxl-${xxl}`])

--- a/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.ts
+++ b/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.ts
@@ -10,10 +10,8 @@ export function buildBreakpointClassnames<T extends string | number | boolean>(
   if (typeof prop === "object") {
     const { sm, md, lg, xl, xxl } = prop
 
-    const mediumPrefix = sm ? "md-" : ""
-
     if (sm) allClassnames.push(styles[`${styleName}-${sm}`])
-    if (md) allClassnames.push(styles[`${styleName}-${mediumPrefix}${md}`])
+    if (md) allClassnames.push(styles[`${styleName}-md-${md}`])
     if (lg) allClassnames.push(styles[`${styleName}-lg-${lg}`])
     if (xl) allClassnames.push(styles[`${styleName}-xl-${xl}`])
     if (xxl) allClassnames.push(styles[`${styleName}-xxl-${xxl}`])


### PR DESCRIPTION
## Description

This builds out the `buildBreakpointClassnames` helper a little bit, allowing for an optional `sm` property on the optional `prop` object. The motivation for this fix was to — by default — have the generated classnames encompass _all_ breakpoints, rather than starting a medium (which was a bit too opinionated to the grid-layout system).

## Solution

You can now do something like
```jsx
<YourComponent propName={{ sm: "yes", md: "no", lg: "maybe" }}>
```
which will generate the following classnames: `.propName-yes`, `.propName-md-no`, and `propName-lg-maybe`.

## Notes
- Tested the Grid Layout system for regressions, and it still works perfectly 🎉 
- The solution I added _only_ accounts for the addition of the `sm` property, and adds or removed the `md-` classname prefix based on the availability of said property. There is definitely a more robust solution floating out there in space — something that does a fancy loop and creates prefixes based on the availability of _all_ breakpoint properties — but as I got into it, I decided it's smarter to just solve for our needs now and in the foreseeable future; rather than over-engineer things.
- This is a branch of the already-merged feature in #181 — thus the redundant changes to the `Flex` stylesheet.

## Does this close any existing issues?
Closes #100 
Referenced in #181 and #172 as well

## Screenshots

Here's an example using the `<Flex>` component, and the newly available `sm` property. The difference between this and our current implementation is that there's now a difference between the small and medium breakpoints:


https://github.com/wethegit/component-library/assets/30575213/741c0a42-f983-401f-b1a0-b81373f695a3


