### PR TITLE
[COMP] Typography and `<Text>` improvements

### DIFF
--- a/packages/wethegit-components-cli/src/registry-index.ts
+++ b/packages/wethegit-components-cli/src/registry-index.ts
@@ -80,7 +80,7 @@ const TAG: Registry = {
 const TEXT: Registry = {
   name: "text",
   category: "component",
-  localDependencies: [TAG, CLASSNAMES, FIXED_FORWARD_REF],
+  localDependencies: [BUILD_BREAKPOINT_CLASSNAMES, CLASSNAMES, FIXED_FORWARD_REF, TAG],
   docsUrl:
     "https://wethegit.github.io/component-library/?path=/docs/components-text-readme--overview",
   postInstallMessages: [

--- a/packages/wethegit-components/package.json
+++ b/packages/wethegit-components/package.json
@@ -67,7 +67,7 @@
     "stylelint-config-custom": "*",
     "tsconfig": "*",
     "typescript": "^5.1.6",
-    "vite": "^4.4.9",
+    "vite": "^4.5.3",
     "wait-on": "^7.2.0",
     "lint-staged-config": "*"
   },

--- a/packages/wethegit-components/src/components/flex/flex.module.scss
+++ b/packages/wethegit-components/src/components/flex/flex.module.scss
@@ -62,7 +62,7 @@
   display: flex;
 }
 
-@include breakpoint-classnames;
+@include breakpoint-classnames(-sm);
 
 @media #{$md-up} {
   @include breakpoint-classnames(-md);

--- a/packages/wethegit-components/src/components/flex/flex.module.scss
+++ b/packages/wethegit-components/src/components/flex/flex.module.scss
@@ -65,17 +65,17 @@
 @include breakpoint-classnames;
 
 @media #{$md-up} {
-  @include breakpoint-classnames(md);
+  @include breakpoint-classnames(-md);
 }
 
 @media #{$lg-up} {
-  @include breakpoint-classnames(lg);
+  @include breakpoint-classnames(-lg);
 }
 
 @media #{$xl-up} {
-  @include breakpoint-classnames(xl);
+  @include breakpoint-classnames(-xl);
 }
 
 @media #{$xxl-up} {
-  @include breakpoint-classnames(xxl);
+  @include breakpoint-classnames(-xxl);
 }

--- a/packages/wethegit-components/src/components/flex/flex.tsx
+++ b/packages/wethegit-components/src/components/flex/flex.tsx
@@ -8,7 +8,7 @@ import styles from "./flex.module.scss"
 
 export type FlexAlign = "flex-start" | "center" | "flex-end" | "baseline" | "stretch"
 
-export type AlignBreakpoints = Partial<Omit<Breakpoints<FlexAlign>, "sm">>
+export type AlignBreakpoints = Partial<Breakpoints<FlexAlign>>
 
 export type FlexJustify =
   | "flex-start"
@@ -17,9 +17,9 @@ export type FlexJustify =
   | "space-between"
   | "space-around"
 
-export type JustifyBreakpoints = Partial<Omit<Breakpoints<FlexJustify>, "sm">>
+export type JustifyBreakpoints = Partial<Breakpoints<FlexJustify>>
 
-export type BooleanBreakpoints = Partial<Omit<Breakpoints<boolean>, "sm">>
+export type BooleanBreakpoints = Partial<Breakpoints<boolean>>
 
 export type FlexProps<TAs extends ElementType> = TagProps<TAs> & {
   /**

--- a/packages/wethegit-components/src/components/grid-layout/column/column.module.scss
+++ b/packages/wethegit-components/src/components/grid-layout/column/column.module.scss
@@ -27,7 +27,7 @@
 }
 
 @media #{$md-up} {
-  @include make-column-classnames;
+  @include make-column-classnames(md);
 }
 
 @media #{$lg-up} {

--- a/packages/wethegit-components/src/components/text/styles/_text-utilities.scss
+++ b/packages/wethegit-components/src/components/text/styles/_text-utilities.scss
@@ -2,11 +2,11 @@
 
 // Calculates the rem value of the provided unitelss pixel value input.
 // This assumes 16px as a base.
-@function calc-rem($value, $base: 16) {
-  @return math.div($value, $base) * 1rem;
+@function calc-rem($value) {
+  @return calc(#{$value} / var(--wtc-base-rem-size) * 1rem);
 }
 
 // This is a variation of the above, which accepts a CSS custom property instead of a number.
-@function calc-rem-css-var($css-var, $base: 16) {
-  @return calc(var($css-var) / 16 * 1rem);
+@function calc-rem-css-var($css-var) {
+  @return calc(var($css-var) / var(--wtc-base-rem-size) * 1rem);
 }

--- a/packages/wethegit-components/src/components/text/styles/text-utilities.stories.mdx
+++ b/packages/wethegit-components/src/components/text/styles/text-utilities.stories.mdx
@@ -19,9 +19,9 @@ import { Meta } from "@storybook/blocks"
 
 ## calc-rem
 
-Signature: `calc-rem(unitless-pixel-value, <base-unitless-size> = 16)`
+Signature: `calc-rem(unitless-pixel-value)`
 
-`calc-rem` Receives a unitless pixel value, and converts it into a `rem` value. This is accomplished by dividing the value by 16, which is the default font size in most browsers.
+`calc-rem` Receives a unitless pixel value, and converts it into a `rem` value. This is accomplished by dividing the value by 16, which is the default font size in most browsers. That `16` can be manipulated via the root-level CSS custom property, `--wtc-base-rem-size`, although the need for this is uncommon.
 
 ### Example
 

--- a/packages/wethegit-components/src/components/text/styles/text.scss
+++ b/packages/wethegit-components/src/components/text/styles/text.scss
@@ -1,6 +1,10 @@
 @use "@local/styles/breakpoints/breakpoints-variables" as *;
 
 :root {
+  // fonts
+  --wtc-font-family-heading: sans-serif;
+  --wtc-font-family-body: sans-serif;
+
   // font sizes
   --wtc-font-size-title-1: 42;
   --wtc-font-size-title-2: 33;

--- a/packages/wethegit-components/src/components/text/styles/text.scss
+++ b/packages/wethegit-components/src/components/text/styles/text.scss
@@ -5,6 +5,9 @@
   --wtc-font-family-heading: sans-serif;
   --wtc-font-family-body: sans-serif;
 
+  // pixel value equivalent to 1rem — this will rarely change
+  --wtc-base-rem-size: 16;
+
   // font sizes
   --wtc-font-size-title-1: 42;
   --wtc-font-size-title-2: 33;

--- a/packages/wethegit-components/src/components/text/styles/text.stories.mdx
+++ b/packages/wethegit-components/src/components/text/styles/text.stories.mdx
@@ -4,7 +4,7 @@ import { Meta } from "@storybook/blocks"
 
 # Text Styles
 
-This file contains the CSS variables that are used to customize the text styles and must be added to your global stylesheet for the `<Text>` component to work properly.
+This file contains information about the CSS variables that are used to customize the text styles. These variables must be added to your global stylesheet for the `<Text>` component to work properly.
 
 - [Font size](#font-size)
 - [Font weight](#font-weight)

--- a/packages/wethegit-components/src/components/text/text.module.scss
+++ b/packages/wethegit-components/src/components/text/text.module.scss
@@ -1,9 +1,18 @@
+@use "@local/styles/breakpoints/breakpoints-variables" as *;
 @use "./styles/text-utilities" as *;
 
 $alignments: start, center, end, justify;
 $variants: "title-1", "title-2", "title-3", "title-4", "title-5", "title-6", "body",
   "body-smaller", "body-larger", "body-legal";
 $weights: "light", "regular", "medium", "semibold", "bold", "black";
+
+@mixin alignment-classnames($prefix: "") {
+  @each $a in $alignments {
+    .align#{$prefix}-#{$a} {
+      text-align: $a;
+    }
+  }
+}
 
 .text {
   margin: 0;
@@ -21,12 +30,6 @@ $weights: "light", "regular", "medium", "semibold", "bold", "black";
   line-height: var(--wtc-line-height-body);
 }
 
-@each $a in $alignments {
-  .align-#{$a} {
-    text-align: $a;
-  }
-}
-
 @each $v in $variants {
   .variant-#{$v} {
     font-size: calc-rem-css-var(--wtc-font-size-#{$v});
@@ -41,4 +44,22 @@ $weights: "light", "regular", "medium", "semibold", "bold", "black";
 
 .noWrap {
   white-space: nowrap;
+}
+
+@include alignment-classnames;
+
+@media #{$md-up} {
+  @include alignment-classnames(-md);
+}
+
+@media #{$lg-up} {
+  @include alignment-classnames(-lg);
+}
+
+@media #{$xl-up} {
+  @include alignment-classnames(-xl);
+}
+
+@media #{$xxl-up} {
+  @include alignment-classnames(-xxl);
 }

--- a/packages/wethegit-components/src/components/text/text.module.scss
+++ b/packages/wethegit-components/src/components/text/text.module.scss
@@ -5,6 +5,7 @@ $alignments: start, center, end, justify;
 $variants: "title-1", "title-2", "title-3", "title-4", "title-5", "title-6", "body",
   "body-smaller", "body-larger", "body-legal";
 $weights: "light", "regular", "medium", "semibold", "bold", "black";
+$wraps: wrap, nowrap, balance, pretty;
 
 @mixin alignment-classnames($prefix: "") {
   @each $a in $alignments {
@@ -16,6 +17,7 @@ $weights: "light", "regular", "medium", "semibold", "bold", "black";
 
 .text {
   margin: 0;
+  text-wrap: pretty;
 }
 
 .textHeading {
@@ -34,6 +36,18 @@ $weights: "light", "regular", "medium", "semibold", "bold", "black";
   line-height: var(--wtc-line-height-body);
 }
 
+.noWrap {
+  white-space: nowrap;
+}
+
+.wrapNormal {
+  text-wrap: wrap;
+}
+
+.wrapBalance {
+  text-wrap: balance;
+}
+
 @each $v in $variants {
   .variant-#{$v} {
     font-size: calc-rem-css-var(--wtc-font-size-#{$v});
@@ -46,8 +60,10 @@ $weights: "light", "regular", "medium", "semibold", "bold", "black";
   }
 }
 
-.noWrap {
-  white-space: nowrap;
+@each $wrap in $wraps {
+  .wrap-#{$wrap} {
+    text-wrap: $wrap;
+  }
 }
 
 @include alignment-classnames(-sm);

--- a/packages/wethegit-components/src/components/text/text.module.scss
+++ b/packages/wethegit-components/src/components/text/text.module.scss
@@ -50,7 +50,7 @@ $weights: "light", "regular", "medium", "semibold", "bold", "black";
   white-space: nowrap;
 }
 
-@include alignment-classnames;
+@include alignment-classnames(-sm);
 
 @media #{$md-up} {
   @include alignment-classnames(-md);

--- a/packages/wethegit-components/src/components/text/text.module.scss
+++ b/packages/wethegit-components/src/components/text/text.module.scss
@@ -19,12 +19,16 @@ $weights: "light", "regular", "medium", "semibold", "bold", "black";
 }
 
 .textHeading {
+  font-family: var(--wtc-font-family-heading);
+
   // This default font weight can be overwritten by the `weight` prop.
   font-weight: var(--wtc-font-weight-bold);
   line-height: var(--wtc-line-height-heading);
 }
 
 .textBody {
+  font-family: var(--wtc-font-family-body);
+
   // This default font weight can be overwritten by the `weight` prop.
   font-weight: var(--wtc-font-weight-regular);
   line-height: var(--wtc-line-height-body);

--- a/packages/wethegit-components/src/components/text/text.tsx
+++ b/packages/wethegit-components/src/components/text/text.tsx
@@ -23,6 +23,8 @@ type TextVariant =
 
 type TextWeight = "light" | "regular" | "medium" | "semibold" | "bold" | "black"
 
+type TextWrap = "wrap" | "nowrap" | "balance" | "pretty"
+
 export type TextProps<TAs extends React.ElementType> = TagProps<TAs> & {
   /**
    * Specifies the inline text alignment. If omitted, inherits the parent alignment.
@@ -37,9 +39,9 @@ export type TextProps<TAs extends React.ElementType> = TagProps<TAs> & {
    */
   weight?: TextWeight
   /**
-   * Use default text-wrapping.
+   * Specify the text-wrapping algorithm. If omitted, the base .text class decalres it as "pretty".
    */
-  wordWrap?: boolean
+  wrap?: TextWrap
   className?: string
 }
 
@@ -47,7 +49,7 @@ export function Text<TAs extends React.ElementType = typeof DEFAULT_ELEMENT>({
   align,
   variant = "body",
   weight,
-  wordWrap = true,
+  wrap,
   className,
   ...props
 }: TextProps<TAs>): JSX.Element {
@@ -59,7 +61,7 @@ export function Text<TAs extends React.ElementType = typeof DEFAULT_ELEMENT>({
     align && buildBreakpointClassnames<TextAlign>(align, styles, "align"),
     styles[`variant-${variant}`],
     weight && styles[`weight-${weight}`],
-    !wordWrap && styles.noWrap,
+    wrap && styles[`wrap-${wrap}`],
     className,
   ])
 

--- a/packages/wethegit-components/src/components/text/text.tsx
+++ b/packages/wethegit-components/src/components/text/text.tsx
@@ -1,12 +1,13 @@
 import { Tag } from "@local/components/tag"
 import type { TagProps } from "@local/components/tag"
-import { classnames } from "@local/utilities"
+import { buildBreakpointClassnames, classnames } from "@local/utilities"
 
 import styles from "./text.module.scss"
 
 const DEFAULT_ELEMENT = "p"
 
 type TextAlign = "start" | "center" | "end" | "justify"
+type TextAlignBreakpoints = Partial<Breakpoints<TextAlign>>
 
 type TextVariant =
   | "title-1"
@@ -26,7 +27,7 @@ export type TextProps<TAs extends React.ElementType> = TagProps<TAs> & {
   /**
    * Specifies the inline text alignment. If omitted, inherits the parent alignment.
    */
-  align?: TextAlign
+  align?: TextAlign | TextAlignBreakpoints
   /**
    * The _visual_ hierarchy of the text. This is not the same as the semantic hierarchy.
    */
@@ -55,7 +56,7 @@ export function Text<TAs extends React.ElementType = typeof DEFAULT_ELEMENT>({
   const classes = classnames([
     styles.text,
     styles[variant.startsWith("title-") ? "textHeading" : "textBody"],
-    align && styles[`align-${align}`],
+    align && buildBreakpointClassnames<TextAlign>(align, styles, "align"),
     styles[`variant-${variant}`],
     weight && styles[`weight-${weight}`],
     !wordWrap && styles.noWrap,

--- a/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.stories.mdx
+++ b/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.stories.mdx
@@ -8,20 +8,21 @@ The `buildBreakpointClassnames` function is designed to generate class names bas
 
 ## Parameters
 
-#### `prop: T | Partial<Omit<Breakpoints<T>, "sm">> | undefined`
+#### `prop: T | Partial<Breakpoints<T>> | undefined`
 
-- The `prop` parameter represents the breakpoint value or an object containing specific breakpoints (md, lg, xl, xxl).
+- The `prop` parameter represents the breakpoint value or an object containing specific breakpoints (sm, md, lg, xl, xxl).
 - It accepts a generic type `T` which can be `string`, `number`, or `boolean`.
-- If `prop` is an object, it can have properties for medium (md), large (lg), extra-large (xl), and double extra-large (xxl) breakpoints.
+- If `prop` is an object, it can have properties for small (sm), medium (md), large (lg), extra-large (xl), and double extra-large (xxl) breakpoints.
 
 #### `styles: Record<string, string>`
 
 - Default CSS modules `styles`. It is used to generate the breakpoint class names and should contain the following classes:
 
-1. `md`: `${styleName}-${value}`
-2. `lg`: `${styleName}-lg-${value}`
-3. `xl`: `${styleName}-xl-${value}`
-4. `xxl`: `${styleName}-xxl-${value}`
+1. `sm`: `${styleName}-${value}`
+2. `md`: `${styleName}-md-${value}`
+3. `lg`: `${styleName}-lg-${value}`
+4. `xl`: `${styleName}-xl-${value}`
+5. `xxl`: `${styleName}-xxl-${value}`
 
 #### `styleName: string`
 
@@ -38,7 +39,7 @@ import { buildBreakpointClassnames } from "path/to/buildBreakpointClassnames"
 import styles from "path/to/styles.module.css"
 
 const breakpointClasses = buildBreakpointClassnames(
-  { md: 2, lg: 3, xl: 4, xxl: 5 },
+  { sm: 1, md: 2, lg: 3, xl: 4, xxl: 5 },
   styles,
   "container"
 )
@@ -47,5 +48,11 @@ const breakpointClasses = buildBreakpointClassnames(
 The above example will return the following array:
 
 ```typescript
-const result = ["container-2", "container-lg-3", "container-xl-4", "container-xxl-5"]
+const result = [
+  "container-1",
+  "container-md-2",
+  "container-lg-3",
+  "container-xl-4",
+  "container-xxl-5",
+]
 ```

--- a/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.ts
+++ b/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.ts
@@ -10,7 +10,7 @@ export function buildBreakpointClassnames<T extends string | number | boolean>(
   if (typeof prop === "object") {
     const { sm, md, lg, xl, xxl } = prop
 
-    if (sm) allClassnames.push(styles[`${styleName}-${sm}`])
+    if (sm) allClassnames.push(styles[`${styleName}-sm-${sm}`])
     if (md) allClassnames.push(styles[`${styleName}-md-${md}`])
     if (lg) allClassnames.push(styles[`${styleName}-lg-${lg}`])
     if (xl) allClassnames.push(styles[`${styleName}-xl-${xl}`])

--- a/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.ts
+++ b/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.ts
@@ -1,16 +1,19 @@
 import type { ClassnamesProps } from "../classnames"
 
 export function buildBreakpointClassnames<T extends string | number | boolean>(
-  prop: T | Partial<Omit<Breakpoints<T>, "sm">> | undefined,
+  prop: T | Partial<Breakpoints<T>> | undefined,
   styles: Record<string, string>,
   styleName: string
 ): ClassnamesProps {
   const allClassnames: ClassnamesProps = []
 
   if (typeof prop === "object") {
-    const { md, lg, xl, xxl } = prop
+    const { sm, md, lg, xl, xxl } = prop
 
-    if (md) allClassnames.push(styles[`${styleName}-${md}`])
+    const mediumPrefix = sm ? "md-" : ""
+
+    if (sm) allClassnames.push(styles[`${styleName}-${sm}`])
+    if (md) allClassnames.push(styles[`${styleName}-${mediumPrefix}${md}`])
     if (lg) allClassnames.push(styles[`${styleName}-lg-${lg}`])
     if (xl) allClassnames.push(styles[`${styleName}-xl-${xl}`])
     if (xxl) allClassnames.push(styles[`${styleName}-xxl-${xxl}`])

--- a/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.ts
+++ b/packages/wethegit-components/src/utilities/build-breakpoint-classnames/build-breakpoint-classnames.ts
@@ -10,10 +10,8 @@ export function buildBreakpointClassnames<T extends string | number | boolean>(
   if (typeof prop === "object") {
     const { sm, md, lg, xl, xxl } = prop
 
-    const mediumPrefix = sm ? "md-" : ""
-
     if (sm) allClassnames.push(styles[`${styleName}-${sm}`])
-    if (md) allClassnames.push(styles[`${styleName}-${mediumPrefix}${md}`])
+    if (md) allClassnames.push(styles[`${styleName}-md-${md}`])
     if (lg) allClassnames.push(styles[`${styleName}-lg-${lg}`])
     if (xl) allClassnames.push(styles[`${styleName}-xl-${xl}`])
     if (xxl) allClassnames.push(styles[`${styleName}-xxl-${xxl}`])


### PR DESCRIPTION
## Description
This PR adds the following:
- The base rem size used in the `calc-rem` utility is now a CSS custom property on the root: `--wtc-base-rem-size`. I've removed the ability to pass it as an argument to the helper.
- Two new font-family CSS custom properties are now available, and set on the `Text` component: `--wtc-font-family-heading` and `--wtc-font-family-body`.
- The `<Text>` component now allows for breakpoint-specific horizontal alignment on the `align` prop (see video).
- Adds a new `wrap` prop which corresponds to the CSS `text-wrap` property; defaults to "pretty".

## Does this close any open issues?
Closes #153 
Closes #162 
Closes #180 

## Notes
- This PR depends on others which are currently open, so please only concern yourself with changes inside the `components/text` directory.

## Screenshots
Here's the breakpoint alignment in action:
https://github.com/wethegit/component-library/assets/30575213/96158a5a-2645-4587-9bc5-a281050d238a

Here's the new `wrap` prop
https://github.com/wethegit/component-library/assets/30575213/fcb974d5-df7a-49d4-9658-bab31e0e2200