### PR TITLE
[COMP] BackToTop: various fixes, per project implementation

### DIFF
--- a/packages/wethegit-components/src/components/back-to-top/back-to-top.module.scss
+++ b/packages/wethegit-components/src/components/back-to-top/back-to-top.module.scss
@@ -1,12 +1,11 @@
-@use "@local/utilities/color/styles/color-utilities" as *;
 @use "@local/styles/animation/animation-utilities" as *;
 
 .button {
   --scale: 1;
 
-  background-color: get-color("black");
+  background-color: #000;
   bottom: 1rem;
-  color: get-color("white");
+  color: #fff;
   opacity: 0;
   padding: 1rem;
   position: fixed;

--- a/packages/wethegit-components/src/components/back-to-top/back-to-top.tsx
+++ b/packages/wethegit-components/src/components/back-to-top/back-to-top.tsx
@@ -42,7 +42,7 @@ export function BackToTop({
 }: BackToTopProps): JSX.Element {
   const buttonRef = useRef<HTMLButtonElement>(null)
   const { prefersReducedMotion } = useUserPrefs()
-  const [setReferenceRef, referenceIsInView] = useInView(1, false, false)
+  const [setReferenceRef, referenceIsInView] = useInView(0, false, false)
 
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -54,10 +54,10 @@ export function BackToTop({
 
       const position = window.scrollY
       const duration = prefersReducedMotion ? 0 : getDuration(position, pixelsPerSecond)
-      let starttime: null | number = null
+      let starttime: number | null = null
 
       const animate = (delta: number) => {
-        if (starttime === null) starttime = 0
+        if (starttime === null) starttime = delta
 
         const playHead = clamp(0, 1, (delta - starttime) / duration)
         const easedPlayHead = easingFunction
@@ -76,7 +76,14 @@ export function BackToTop({
 
       requestAnimationFrame(animate)
     },
-    [prefersReducedMotion]
+    [
+      easingFunction,
+      focusOnCompleteCssSelector,
+      onComplete,
+      pixelsPerSecond,
+      prefersReducedMotion,
+      props.onClick,
+    ]
   )
 
   return (
@@ -92,7 +99,7 @@ export function BackToTop({
         ref={buttonRef}
         className={classnames([
           styles.button,
-          (!referenceIsInView || revealThreshold.startsWith("0")) && styles.buttonShown,
+          (revealThreshold.startsWith("0") || !referenceIsInView) && styles.buttonShown,
           className,
         ])}
         onClick={handleClick}


### PR DESCRIPTION
## Description
This PR fixes a few blunders that I didn't catch until using `<BackToTop>` on a project:
- Set inView callback to only fire at the `0` threshold instead of `1`
- Add missing `useCallback` dependencies
- other minor tweaks

Also removes the dependency on the COLORS utility, as it's not something a user will necessarily want.