### PR TITLE
fix(Spacing): adds missing breakpoint classes for non-directional spacing

### DIFF
--- a/packages/wethegit-components/src/utilities/spacing/spacing.ts
+++ b/packages/wethegit-components/src/utilities/spacing/spacing.ts
@@ -59,15 +59,19 @@ for (const bp of BREAKPOINTS) {
       // e.g. spacing.margin[1]
       spacing[prop][i] = styles[`${prop}-${i}`]
 
+      // base spacing, per breakpoint
+      // e.g. spacing.xl.margin[2]
+      spacing[bp][prop] ||= {} as Spacing["md"]["margin"]
+      spacing[bp][prop][i] = styles[`${prop}-${bp}-${i}`]
+
       for (const dir of directions) {
         // base directional spacing
         // e.g. spacing.margin.left[1]
         spacing[prop][dir] ||= {} as Spacing["margin"]["left"]
         spacing[prop][dir][i] = styles[`${prop}-${dir}-${i}`]
 
-        // breakpoint spacing
+        // breakpoint directional spacing
         // e.g. spacing.md.margin.left[1]
-        spacing[bp][prop] ||= {} as Spacing["md"]["margin"]
         spacing[bp][prop][dir] ||= {} as Spacing["md"]["margin"]["left"]
         spacing[bp][prop][dir][i] = styles[`${prop}-${dir}-${bp}-${i}`]
       }


### PR DESCRIPTION
## Description

This PR adds a missing collection of breakpoint-specific classes for spacing that _doesn't_ specify a direction. For example, `margin[2]` and `padding[6]`. You can now do:
```
spacing.md.margin[2]
spacing.lg.margin[4]
```

## Notes
Fixes #173 

## Screenshots

https://github.com/wethegit/component-library/assets/30575213/67af3e26-9485-45e0-9bfc-ef847d7656fd

