### PR TITLE
[COMP]: `Color`: export the `ColorNames` type

### DIFF
--- a/packages/wethegit-components/src/utilities/color/color.ts
+++ b/packages/wethegit-components/src/utilities/color/color.ts
@@ -2,7 +2,7 @@ import styles from "./color.module.scss"
 
 const colorNames = ["black", "white"] as const
 
-type ColorNames = (typeof colorNames)[number]
+export type ColorNames = (typeof colorNames)[number]
 
 type ColorNamesToStyles = Record<ColorNames, string>
 


### PR DESCRIPTION
## Description

Exports the `ColorNames` type. Handy for use in other components that generate color variations

Resolves #156 