### PR TITLE
[COMP]: add `useBreakpoints` hook

### DIFF
--- a/packages/tsconfig/react-library.json
+++ b/packages/tsconfig/react-library.json
@@ -4,7 +4,7 @@
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "lib": ["dom", "ES2015"],
+    "lib": ["dom", "esnext"],
     "module": "ESNext",
     "target": "es6"
   }

--- a/packages/wethegit-components-cli/src/registry-index.ts
+++ b/packages/wethegit-components-cli/src/registry-index.ts
@@ -33,6 +33,13 @@ const BREAKPOINTS_TYPE: Registry = {
   dontShowOnPrompt: true,
 }
 
+/* HOOKS */
+const USE_BREAKPOINTS: Registry = {
+  name: "use-breakpoints",
+  category: "hook",
+  dontShowOnPrompt: true,
+}
+
 /* UTILITIES */
 const FIXED_FORWARD_REF: Registry = {
   name: "fixed-forward-ref",
@@ -207,5 +214,7 @@ export const REGISTRY_INDEX: RegistryIndex = {
   [COLOR.name]: COLOR,
   [SPACING.name]: SPACING,
   [VISIBILITY.name]: VISIBILITY,
+
+  [USE_BREAKPOINTS.name]: USE_BREAKPOINTS,
 }
 /* END REGISTRY INDEX */

--- a/packages/wethegit-components-cli/src/registry-index.ts
+++ b/packages/wethegit-components-cli/src/registry-index.ts
@@ -37,7 +37,6 @@ const BREAKPOINTS_TYPE: Registry = {
 const USE_BREAKPOINTS: Registry = {
   name: "use-breakpoints",
   category: "hook",
-  dontShowOnPrompt: true,
 }
 
 /* UTILITIES */
@@ -182,7 +181,7 @@ const VISUALLY_HIDDEN_LINKS: Registry = {
 const BREAKPOINT_SNIPE: Registry = {
   name: "breakpoint-snipe",
   category: "component",
-  localDependencies: [CLASSNAMES],
+  localDependencies: [CLASSNAMES, USE_BREAKPOINTS],
 }
 
 const BACK_TO_TOP: Registry = {

--- a/packages/wethegit-components/src/components/breakpoint-snipe/breakpoint-snipe.module.scss
+++ b/packages/wethegit-components/src/components/breakpoint-snipe/breakpoint-snipe.module.scss
@@ -1,5 +1,3 @@
-@use "@local/styles/breakpoints/breakpoints-variables" as *;
-
 .breakpointSnipe {
   align-items: center;
   aspect-ratio: 1/1;
@@ -12,45 +10,9 @@
   position: fixed;
   right: 0;
   width: 40px;
-
-  &::before {
-    content: "sm";
-  }
 }
 
 .breakpointSnipeDark {
   background-color: black;
   color: white;
-}
-
-@media #{$md-up} {
-  .breakpointSnipe {
-    &::before {
-      content: "md";
-    }
-  }
-}
-
-@media #{$lg-up} {
-  .breakpointSnipe {
-    &::before {
-      content: "lg";
-    }
-  }
-}
-
-@media #{$xl-up} {
-  .breakpointSnipe {
-    &::before {
-      content: "xl";
-    }
-  }
-}
-
-@media #{$xxl-up} {
-  .breakpointSnipe {
-    &::before {
-      content: "xxl";
-    }
-  }
 }

--- a/packages/wethegit-components/src/components/breakpoint-snipe/breakpoint-snipe.tsx
+++ b/packages/wethegit-components/src/components/breakpoint-snipe/breakpoint-snipe.tsx
@@ -1,3 +1,4 @@
+import { useBreakpoints } from "@local/hooks"
 import { classnames } from "@local/utilities"
 
 import styles from "./breakpoint-snipe.module.scss"
@@ -19,6 +20,8 @@ export function BreakpointSnipe({
   className,
   ...props
 }: BreakpointSnipeProps) {
+  const { breakpoint } = useBreakpoints()
+
   return (
     <div
       className={classnames([
@@ -28,6 +31,8 @@ export function BreakpointSnipe({
       ])}
       {...props}
       aria-hidden="true"
-    />
+    >
+      {breakpoint}
+    </div>
   )
 }

--- a/packages/wethegit-components/src/hooks/index.ts
+++ b/packages/wethegit-components/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./use-breakpoints"

--- a/packages/wethegit-components/src/hooks/use-breakpoints/index.ts
+++ b/packages/wethegit-components/src/hooks/use-breakpoints/index.ts
@@ -1,0 +1,1 @@
+export { useBreakpoints } from "./use-breakpoints"

--- a/packages/wethegit-components/src/hooks/use-breakpoints/readme.stories.mdx
+++ b/packages/wethegit-components/src/hooks/use-breakpoints/readme.stories.mdx
@@ -1,0 +1,33 @@
+import { Meta, Markdown } from "@storybook/blocks"
+
+<Meta title="hooks/useBreakpoints" />
+
+# useBreakpoints
+
+Location: `@local/hooks/use-breakpoints.ts`
+
+`useBreakpoints` is a custom React hook that returns information about the current media-query/breakpoint. See [Breakpoint docs](/docs/styles-breakpoints-breakpoints-variables--overview). The hook comes pre-loaded with the component library, and is added to your project upon running the `@wethegit/components-cli init` command.
+
+## Usage example
+
+```jsx
+import { useBreakpoints } from "@local/hooks"
+
+function YourComponent() {
+  const { breakpoint } = useBreakpoints()
+
+  return <h1>{breakpoint === "sm" ? 🐁 : 🐘}</h1>
+}
+```
+
+## Return value
+
+<Markdown>
+  {`
+| property   | type                          | description                                                              |
+| ---------- | ----------------------------- | ------------------------------------------------------------------------ |
+| breakpoint | "sm", "md", "lg", "xl", "xxl" | A string representation of the current breakpoint.                       |
+| mdUp       | boolean, undefined            | Whether or not the current breakpoint can be considered "medium-and-up". |
+| lgUp       | boolean, undefined            | Whether or not the current breakpoint can be considered "large-and-up".  |
+`}
+</Markdown>

--- a/packages/wethegit-components/src/hooks/use-breakpoints/readme.stories.mdx
+++ b/packages/wethegit-components/src/hooks/use-breakpoints/readme.stories.mdx
@@ -24,10 +24,12 @@ function YourComponent() {
 
 <Markdown>
   {`
-| property   | type                          | description                                                              |
-| ---------- | ----------------------------- | ------------------------------------------------------------------------ |
-| breakpoint | "sm", "md", "lg", "xl", "xxl" | A string representation of the current breakpoint.                       |
-| mdUp       | boolean, undefined            | Whether or not the current breakpoint can be considered "medium-and-up". |
-| lgUp       | boolean, undefined            | Whether or not the current breakpoint can be considered "large-and-up".  |
+| property   | type                          | description                                                               |
+| ---------- | ----------------------------- | ------------------------------------------------------------------------- |
+| breakpoint | "sm", "md", "lg", "xl", "xxl" | A string representation of the current breakpoint.                        |
+| mdUp       | boolean, undefined            | Whether or not the current breakpoint can be considered "medium-and-up".  |
+| lgUp       | boolean, undefined            | Whether or not the current breakpoint can be considered "large-and-up".   |
+| xlUp       | boolean, undefined            | Whether or not the current breakpoint can be considered "xlarge-and-up".  |
+| xxlUp      | boolean, undefined            | Whether or not the current breakpoint can be considered "xxlarge-and-up". |
 `}
 </Markdown>

--- a/packages/wethegit-components/src/hooks/use-breakpoints/use-breakpoints.module.scss
+++ b/packages/wethegit-components/src/hooks/use-breakpoints/use-breakpoints.module.scss
@@ -1,0 +1,12 @@
+/* stylelint-disable selector-pseudo-class-no-unknown */
+/* stylelint-disable property-no-unknown */
+
+@import "@local/styles/breakpoints/breakpoints-variables";
+
+:export {
+  lg: $lg-only;
+  md: $md-only;
+  sm: $sm-only;
+  xl: $xl-only;
+  xxl: $xxl-up;
+}

--- a/packages/wethegit-components/src/hooks/use-breakpoints/use-breakpoints.ts
+++ b/packages/wethegit-components/src/hooks/use-breakpoints/use-breakpoints.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import breakpointSettings from "./use-breakpoints.module.scss"
 
@@ -29,9 +29,24 @@ export function useBreakpoints() {
     }
   }, [])
 
-  return {
-    breakpoint,
-    mdUp: breakpoint && breakpoint !== "sm",
-    lgUp: breakpoint && !["sm", "md"].includes(breakpoint),
-  }
+  const breakpointData = useMemo(() => {
+    let xxlUp, xlUp, lgUp, mdUp
+
+    if (breakpoint) {
+      xxlUp = breakpoint === "xxl"
+      xlUp = xxlUp || breakpoint === "xl"
+      lgUp = xlUp || breakpoint === "lg"
+      mdUp = lgUp || breakpoint === "md"
+    }
+
+    return {
+      breakpoint,
+      mdUp,
+      lgUp,
+      xlUp,
+      xxlUp,
+    }
+  }, [breakpoint])
+
+  return breakpointData
 }

--- a/packages/wethegit-components/src/hooks/use-breakpoints/use-breakpoints.ts
+++ b/packages/wethegit-components/src/hooks/use-breakpoints/use-breakpoints.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react"
+
+import breakpointSettings from "./use-breakpoints.module.scss"
+
+const BREAKPOINTS: [Breakpoint, string][] = Object.entries(breakpointSettings).map(
+  ([key, val]) => [key as Breakpoint, val.replaceAll('"', "")]
+)
+
+export function useBreakpoints() {
+  const [breakpoint, setBreakpoint] = useState<Breakpoint | undefined>("sm")
+
+  useEffect(() => {
+    let resizeTimer: ReturnType<typeof setTimeout>
+
+    function onResize() {
+      clearTimeout(resizeTimer)
+      resizeTimer = setTimeout(() => {
+        setBreakpoint(BREAKPOINTS.find((bp) => window.matchMedia(bp[1]).matches)?.[0])
+      }, 200)
+    }
+
+    onResize()
+
+    window.addEventListener("resize", onResize)
+
+    return () => {
+      clearTimeout(resizeTimer)
+      window.removeEventListener("resize", onResize)
+    }
+  }, [])
+
+  return {
+    breakpoint,
+    mdUp: breakpoint && breakpoint !== "sm",
+    lgUp: breakpoint && !["sm", "md"].includes(breakpoint),
+  }
+}


### PR DESCRIPTION
## Description

- adds a react hook which allows you to hook into the current breakpoint
- adds documentation for the new hook
- refactors the BreakpointSnipe to use this new hook, instead of the hard-coded, duplicated CSS values directly in the stylesheet

## Additional Notes

- In order to use `String.prototype.replaceAll` in my code, I had to update one of our `tsconfigs` to use `esnext` for the `"lib"` property. Let me know if this is a problem
- I was intending for this hook to be pulled down with the library on `init` — but I think that will require some extra scripting for the `init` command.
- I chose to debounce this calculation on resize, by 200ms.
- Closes #148 

## Screenshots

https://github.com/wethegit/component-library/assets/30575213/f51f5b29-ad71-46c4-82b1-6d9f165f291c


