### PR TITLE
[COMP] fix: Add missing component classnames

### DIFF
--- a/.changeset/swift-dolls-look.md
+++ b/.changeset/swift-dolls-look.md
@@ -1,0 +1,5 @@
+---
+"@wethegit/components": patch
+---
+
+Adds missing prefix-less classnames for Column, Flex, and Text components.

--- a/packages/wethegit-components/package.json
+++ b/packages/wethegit-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/components",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "main": "./src/index.ts",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/wethegit-components/src/components/flex/flex.module.scss
+++ b/packages/wethegit-components/src/components/flex/flex.module.scss
@@ -62,6 +62,7 @@
   display: flex;
 }
 
+@include breakpoint-classnames;
 @include breakpoint-classnames(-sm);
 
 @media #{$md-up} {

--- a/packages/wethegit-components/src/components/grid-layout/column/column.module.scss
+++ b/packages/wethegit-components/src/components/grid-layout/column/column.module.scss
@@ -26,6 +26,8 @@
   padding-inline: 0;
 }
 
+@include make-column-classnames;
+
 @media #{$md-up} {
   @include make-column-classnames(md);
 }

--- a/packages/wethegit-components/src/components/text/text.module.scss
+++ b/packages/wethegit-components/src/components/text/text.module.scss
@@ -66,6 +66,7 @@ $wraps: wrap, nowrap, balance, pretty;
   }
 }
 
+@include alignment-classnames;
 @include alignment-classnames(-sm);
 
 @media #{$md-up} {


### PR DESCRIPTION
# [COMP] fix: Add missing component classnames

## Description

A few components that use the `buildBreakpointClassnames()` function were missing their _non-prefixed_ counterparts. This meant that you could not do something like `<Flex justify="center">` because we _only_ had breakpoint-prefixed classnames. I.e. you had to use the breakpoint object for these props to work.

## Solution
Add one extra call to the SASS mixins which generate these classes, passing an empty string as a prefix. This applies to `Column`, `Flex`, and `Text`.


## Additional Notes

Fixes #194 
