### PR TITLE
feature: add tests for aria-hidden and aria-label for icon component

### DIFF
--- a/packages/wethegit-components/src/components/icon/icon/icon.stories.tsx
+++ b/packages/wethegit-components/src/components/icon/icon/icon.stories.tsx
@@ -43,15 +43,16 @@ export const Default: Story = {
 
 export const WithAlt: Story = {
   render: (args) => {
-    return <Icon {...args} alt="play" />
+    return <Icon {...args} />
   },
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement)
+    if (args.alt) {
+      const icon = canvas.getByLabelText(args.alt)
 
-    const icon = canvas.getByLabelText("play")
-
-    expect(icon).toBeInTheDocument()
-    expect(icon.getAttribute("aria-label")).toEqual("play")
-    expect(icon.getAttribute("aria-hidden")).toEqual("false")
+      expect(icon).toBeInTheDocument()
+      expect(icon.getAttribute("aria-label")).toEqual(args.alt)
+      expect(icon.getAttribute("aria-hidden")).toEqual("false")
+    }
   },
 }

--- a/packages/wethegit-components/src/components/icon/icon/icon.stories.tsx
+++ b/packages/wethegit-components/src/components/icon/icon/icon.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { expect, within } from "@storybook/test"
+
 import { Icon, IconDefs, IconSymbol } from "@local/components"
 
 const meta = {

--- a/packages/wethegit-components/src/components/icon/icon/icon.stories.tsx
+++ b/packages/wethegit-components/src/components/icon/icon/icon.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react"
-
+import { expect, within } from "@storybook/test"
 import { Icon, IconDefs, IconSymbol } from "@local/components"
 
 const meta = {
@@ -28,4 +28,30 @@ type Story = StoryObj<typeof Icon>
 
 export const Default: Story = {
   render: (args) => <Icon {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const icon = canvas.getByRole("img", { hidden: true })
+
+    expect(icon).toBeInTheDocument()
+
+    // without an alt prop provided, aria-hidden should be true
+    expect(icon.getAttribute("aria-hidden")).toEqual("true")
+    expect(icon.hasAttribute("aria-label")).toBe(false)
+  },
+}
+
+export const WithAlt: Story = {
+  render: (args) => {
+    return <Icon {...args} alt="play" />
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const icon = canvas.getByLabelText("play")
+
+    expect(icon).toBeInTheDocument()
+    expect(icon.getAttribute("aria-label")).toEqual("play")
+    expect(icon.getAttribute("aria-hidden")).toEqual("false")
+  },
 }


### PR DESCRIPTION
## Description

Adds tests for the `Icon` component testing the `aria-hidden` and `aria-label` attributes; addresses #130 .

## Solution

Creates a `Story` for two cases - rendering an `Icon` with and without an `alt` prop value.

## Testing
- Checkout this branch
- In one terminal, run `cd packages/wethegit-components`, followed by `yarn start`
- In a separate terminal, run `yarn test-storybook`
- Navigate to `http://localhost:6006/?path=/story/components-icon--default` and `http://localhost:6006/?path=/story/components-icon--with-alt` and verify that the tests under the `Interactions` tab have all passed, respectively
- Additionally, go to the `Controls` tab and try setting values there, hitting the refresh icon by the top of the canvas and verifying the tests run and pass in the `Interactions` tab
