### PR TITLE
fix: ci using deprecated action

### DIFF
--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -3,10 +3,6 @@ name: "Storybook Tests"
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
-    paths:
-      - "packages/wethegit-components/**"
-      - "yarn.lock"
-      - "**/package.json"
 
   push:
     branches:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
-      - name: Upload artifac
+      - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: "./packages/wethegit-components/storybook-static"

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -46,13 +46,13 @@ jobs:
         run: npx turbo run build --filter=@wethegit/components
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+      - name: Upload artifac
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "./packages/wethegit-components/storybook-static"
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Description

GitHub deprecated the uploads artifacts action v3 which is what we used and now CI is breaking.
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

This PR fixes that.
