### PR TITLE
(components) fix: incorrect InView delay calculation

### DIFF
--- a/.changeset/forty-boats-battle.md
+++ b/.changeset/forty-boats-battle.md
@@ -1,0 +1,5 @@
+---
+"@wethegit/components": patch
+---
+
+Fixes an issue with the InViewItem component, where the delays were being caluculated incorrectly. For example, using a delay value of `8` would return a `0.4s` value instead of a `0.8s` value.

--- a/packages/wethegit-components/src/components/in-view/components/in-view-item/styles/_in-view-utilities.scss
+++ b/packages/wethegit-components/src/components/in-view/components/in-view-item/styles/_in-view-utilities.scss
@@ -4,8 +4,8 @@
  * Returns a value in seconds, equal to the number passed divided by 10. (2 => 0.2s)
  * Useful when generating duration or delay classnames.
  */
-@function get-duration($i, $subDivisions: 10) {
-  @return calc(#{$i} / #{$subDivisions} * 1s * var(--duration-factor, 1));
+@function get-duration($i) {
+  @return calc(#{$i} / 10s * var(--duration-factor, 1));
 }
 
 /**

--- a/packages/wethegit-components/src/components/in-view/components/in-view-item/styles/in-view-item.module.scss
+++ b/packages/wethegit-components/src/components/in-view/components/in-view-item/styles/in-view-item.module.scss
@@ -38,15 +38,15 @@
 // Example: `.delay2` is a 0.2s delay.
 @for $i from 0 through 10 {
   .delay#{$i} {
-    --delay: #{get-duration($i, 10)};
+    --delay: #{get-duration($i)};
   }
 
   .staggerAmount#{$i} {
-    --stagger-amount: #{get-duration($i, 10)};
+    --stagger-amount: #{get-duration($i)};
   }
 
   .staggerDelay#{$i} {
-    --stagger-delay: #{get-duration($i, 10)};
+    --stagger-delay: #{get-duration($i)};
   }
 }
 
@@ -55,10 +55,10 @@
 // Example: `.duration15` is a 1.5s duration.
 @for $i from 0 through 20 {
   .duration#{$i} {
-    --duration: #{get-duration($i, 20)};
+    --duration: #{get-duration($i)};
   }
 
   .staggerDuration#{$i} {
-    --stagger-duration: #{get-duration($i, 20)};
+    --stagger-duration: #{get-duration($i)};
   }
 }


### PR DESCRIPTION
Time tracking: https://wethecollective.teamwork.com/app/tasks/22769488

## Description

Fixes an issue on the `get-duration` Sass function, where the delay was being calculated incorrectly. For example, passing `delay={8}` should get you a delay of `0.8s`, but it was returning `0.4s`.

## Solution

- Removed the second argument (`$subdivisions`) from this helper entirely, as it doesn't seem helpful. We never run into cases where we need to divide our inputs by any other increments than 10. It also just confuses the usage a bit.

## Additional Notes

- Fixes #451 
- I made this a patch update, since these components are not compiled. Shouldn't be an issue, but lmk if the team would prefer this as a major bump.
