### PR TITLE
Version Packages

### DIFF
--- a/.changeset/forty-boats-battle.md
+++ b/.changeset/forty-boats-battle.md
@@ -1,5 +1,0 @@
----
-"@wethegit/components": patch
----
-
-Fixes an issue with the InViewItem component, where the delays were being caluculated incorrectly. For example, using a delay value of `8` would return a `0.4s` value instead of a `0.8s` value.

--- a/packages/wethegit-components/CHANGELOG.md
+++ b/packages/wethegit-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @wethegit/components
 
+## 3.0.2
+
+### Patch Changes
+
+- 701c246: Fixes an issue with the InViewItem component, where the delays were being caluculated incorrectly. For example, using a delay value of `8` would return a `0.4s` value instead of a `0.8s` value.
+
 ## 3.0.1
 
 ### Patch Changes

--- a/packages/wethegit-components/package.json
+++ b/packages/wethegit-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/components",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": "./src/index.ts",
   "sideEffects": false,
   "license": "MIT",


### PR DESCRIPTION
Bumps components to `3.0.2`. Manual PR (as opposed to changeset-generated) due to actions not running properly

Fixes an issue with the InViewItem component, where the delays were being calculated incorrectly. For example, using a delay value of `8` would return a `0.4s` value instead of a `0.8s` value.